### PR TITLE
Suppress compile time warnings

### DIFF
--- a/ext/winevt/extconf.rb
+++ b/ext/winevt/extconf.rb
@@ -16,8 +16,8 @@ have_library("advapi32")
 have_library("ole32")
 
 $LDFLAGS << " -lwevtapi -ladvapi32 -lole32"
-$CFLAGS << " -std=c99 -fPIC -fms-extensions "
-$CXXFLAGS << " -std=c++11 -fPIC -fms-extensions "
+$CFLAGS << " -Wall -std=c99 -fPIC -fms-extensions "
+$CXXFLAGS << " -Wall -std=c++11 -fPIC -fms-extensions "
 # $CFLAGS << " -g -O0 -ggdb"
 # $CXXFLAGS << " -g -O0 -ggdb"
 

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -26,8 +26,6 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-  char* wstr_to_mbstr(UINT cp, const WCHAR* wstr, int clen);
-  void free_allocated_mbstr(const char* str);
   VALUE wstr_to_rb_str(UINT cp, const WCHAR* wstr, int clen);
   WCHAR* render_event(EVT_HANDLE handle, DWORD flags);
   WCHAR* get_description(EVT_HANDLE handle);

--- a/ext/winevt/winevt_channel.c
+++ b/ext/winevt/winevt_channel.c
@@ -63,7 +63,7 @@ rb_winevt_channel_each(VALUE self)
     winevtChannel->channels = hChannels;
   } else {
     _snprintf_s(
-      errBuf, 256, _TRUNCATE, "Failed to enumerate channels with %s\n", GetLastError());
+      errBuf, 256, _TRUNCATE, "Failed to enumerate channels with %lu\n", GetLastError());
     rb_raise(rb_eRuntimeError, errBuf);
   }
 

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -195,6 +195,10 @@ get_evt_seek_flag_from_cstr(char* flag_str)
     return EvtSeekOriginMask;
   else if (strcmp(flag_str, "strict") == 0)
     return EvtSeekStrict;
+  else
+    rb_raise(rb_eArgError, "Unknown seek flag: %s", flag_str);
+
+  return 0;
 }
 
 static VALUE
@@ -202,7 +206,7 @@ rb_winevt_query_seek(VALUE self, VALUE bookmark_or_flag)
 {
   struct WinevtQuery* winevtQuery;
   struct WinevtBookmark* winevtBookmark = NULL;
-  DWORD flag;
+  DWORD flag = 0;
 
   switch (TYPE(bookmark_or_flag)) {
     case T_SYMBOL:

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -253,11 +253,7 @@ rb_winevt_query_close_handle(VALUE self)
 static VALUE
 rb_winevt_query_each_yield(VALUE self)
 {
-  struct WinevtQuery* winevtQuery;
-
   RETURN_ENUMERATOR(self, 0, 0);
-
-  TypedData_Get_Struct(self, struct WinevtQuery, &rb_winevt_query_type, winevtQuery);
 
   rb_yield_values(3,
                   rb_winevt_query_render(self),
@@ -270,11 +266,8 @@ rb_winevt_query_each_yield(VALUE self)
 static VALUE
 rb_winevt_query_each(VALUE self)
 {
-  struct WinevtQuery* winevtQuery;
-
   RETURN_ENUMERATOR(self, 0, 0);
 
-  TypedData_Get_Struct(self, struct WinevtQuery, &rb_winevt_query_type, winevtQuery);
   while (rb_winevt_query_next(self)) {
     rb_ensure(rb_winevt_query_each_yield, self, rb_winevt_query_close_handle, self);
   }

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -226,12 +226,7 @@ rb_winevt_subscribe_close_handle(VALUE self)
 static VALUE
 rb_winevt_subscribe_each_yield(VALUE self)
 {
-  struct WinevtSubscribe* winevtSubscribe;
-
   RETURN_ENUMERATOR(self, 0, 0);
-
-  TypedData_Get_Struct(
-    self, struct WinevtSubscribe, &rb_winevt_subscribe_type, winevtSubscribe);
 
   rb_yield_values(3,
                   rb_winevt_subscribe_render(self),
@@ -244,12 +239,7 @@ rb_winevt_subscribe_each_yield(VALUE self)
 static VALUE
 rb_winevt_subscribe_each(VALUE self)
 {
-  struct WinevtSubscribe* winevtSubscribe;
-
   RETURN_ENUMERATOR(self, 0, 0);
-
-  TypedData_Get_Struct(
-    self, struct WinevtSubscribe, &rb_winevt_subscribe_type, winevtSubscribe);
 
   while (rb_winevt_subscribe_next(self)) {
     rb_ensure(

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -35,7 +35,7 @@ render_event(EVT_HANDLE handle, DWORD flags)
       try {
         buffer.resize(bufferSize);
         buffer.shrink_to_fit();
-      } catch (std::bad_alloc e) {
+      } catch (std::bad_alloc &e) {
         status = ERROR_OUTOFMEMORY;
         bufferSize = 0;
         rb_raise(rb_eWinevtQueryError, "Out of memory");
@@ -112,7 +112,7 @@ get_values(EVT_HANDLE handle)
       try {
         buffer.resize(bufferSize);
         buffer.shrink_to_fit();
-      } catch (std::bad_alloc e) {
+      } catch (std::bad_alloc &e) {
         status = ERROR_OUTOFMEMORY;
         bufferSize = 0;
         rb_raise(rb_eWinevtQueryError, "Out of memory");

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -97,12 +97,10 @@ get_values(EVT_HANDLE handle)
   ULONG bufferSize = 0;
   ULONG bufferSizeNeeded = 0;
   DWORD status, propCount = 0;
-  char* result;
   LPTSTR msgBuf;
   WCHAR* tmpWChar = nullptr;
   VALUE userValues = rb_ary_new();
 
-  static PCWSTR eventProperties[] = { L"Event/EventData/Data[1]" };
   EVT_HANDLE renderContext = EvtCreateRenderContext(0, nullptr, EvtRenderContextUser);
   if (renderContext == nullptr) {
     rb_raise(rb_eWinevtQueryError, "Failed to create renderContext");
@@ -455,7 +453,6 @@ get_description(EVT_HANDLE handle)
 {
 #define BUFSIZE 4096
   std::vector<WCHAR> buffer(BUFSIZE);
-  ULONG bufferSize = 0;
   ULONG bufferSizeNeeded = 0;
   ULONG status, count;
   std::vector<WCHAR> result;

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -27,7 +27,7 @@ render_event(EVT_HANDLE handle, DWORD flags)
   ULONG bufferSizeNeeded = 0;
   ULONG status, count;
   static WCHAR* result;
-  LPTSTR msgBuf;
+  CHAR msgBuf[256];
 
   do {
     if (bufferSizeNeeded > bufferSize) {
@@ -57,20 +57,15 @@ render_event(EVT_HANDLE handle, DWORD flags)
   } while (status == ERROR_INSUFFICIENT_BUFFER);
 
   if (status != ERROR_SUCCESS) {
-    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                    FORMAT_MESSAGE_IGNORE_INSERTS,
-                  nullptr,
-                  status,
-                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                  msgBuf,
-                  0,
-                  nullptr);
-
-    VALUE errmsg = rb_str_new2(msgBuf);
-    LocalFree(msgBuf);
-
+    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                   nullptr,
+                   status,
+                   MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                   msgBuf,
+                   sizeof(msgBuf),
+                   nullptr);
     rb_raise(
-      rb_eWinevtQueryError, "ErrorCode: %ld\nError: %s\n", status, RSTRING_PTR(errmsg));
+      rb_eWinevtQueryError, "ErrorCode: %ld\nError: %s\n", status, msgBuf);
   }
 
   result = _wcsdup(&buffer.front());
@@ -97,7 +92,7 @@ get_values(EVT_HANDLE handle)
   ULONG bufferSize = 0;
   ULONG bufferSizeNeeded = 0;
   DWORD status, propCount = 0;
-  LPTSTR msgBuf;
+  CHAR msgBuf[256];
   WCHAR* tmpWChar = nullptr;
   VALUE userValues = rb_ary_new();
 
@@ -134,20 +129,15 @@ get_values(EVT_HANDLE handle)
   } while (status == ERROR_INSUFFICIENT_BUFFER);
 
   if (status != ERROR_SUCCESS) {
-    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                    FORMAT_MESSAGE_IGNORE_INSERTS,
-                  nullptr,
-                  status,
-                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                  msgBuf,
-                  0,
-                  nullptr);
-
-    VALUE errmsg = rb_str_new2(msgBuf);
-    LocalFree(msgBuf);
-
+    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                   nullptr,
+                   status,
+                   MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                   msgBuf,
+                   sizeof(msgBuf),
+                   nullptr);
     rb_raise(
-      rb_eWinevtQueryError, "ErrorCode: %lu\nError: %s\n", status, RSTRING_PTR(errmsg));
+      rb_eWinevtQueryError, "ErrorCode: %lu\nError: %s\n", status, msgBuf);
   }
 
   PEVT_VARIANT pRenderedValues = reinterpret_cast<PEVT_VARIANT>(&buffer.front());
@@ -456,7 +446,7 @@ get_description(EVT_HANDLE handle)
   ULONG bufferSizeNeeded = 0;
   ULONG status, count;
   std::vector<WCHAR> result;
-  LPTSTR msgBuf;
+  CHAR msgBuf[256];
   EVT_HANDLE hMetadata = nullptr;
 
   static PCWSTR eventProperties[] = { L"Event/System/Provider/@Name" };
@@ -479,20 +469,15 @@ get_description(EVT_HANDLE handle)
   }
 
   if (status != ERROR_SUCCESS) {
-    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                    FORMAT_MESSAGE_IGNORE_INSERTS,
-                  nullptr,
-                  status,
-                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                  msgBuf,
-                  0,
-                  nullptr);
-
-    VALUE errmsg = rb_str_new2(msgBuf);
-    LocalFree(msgBuf);
-
+    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                   nullptr,
+                   status,
+                   MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                   msgBuf,
+                   sizeof(msgBuf),
+                   nullptr);
     rb_raise(
-      rb_eWinevtQueryError, "ErrorCode: %lu\nError: %s\n", status, RSTRING_PTR(errmsg));
+      rb_eWinevtQueryError, "ErrorCode: %lu\nError: %s\n", status, msgBuf);
   }
 
   // Obtain buffer as EVT_VARIANT pointer. To avoid ErrorCide 87 in EvtRender.

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -148,7 +148,7 @@ get_values(EVT_HANDLE handle)
   std::vector<CHAR> sResult(256);
   VALUE rbObj;
 
-  for (int i = 0; i < propCount; i++) {
+  for (DWORD i = 0; i < propCount; i++) {
     switch (pRenderedValues[i].Type) {
       case EvtVarTypeNull:
         rb_ary_push(userValues, Qnil);

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -287,13 +287,11 @@ get_values(EVT_HANDLE handle)
         }
         break;
       case EvtVarTypeHexInt32:
-        rbObj = ULONG2NUM(pRenderedValues[i].UInt32Val);
-        rbObj = rb_sprintf("%#x", rbObj);
+        rbObj = rb_sprintf("%#x", pRenderedValues[i].UInt32Val);
         rb_ary_push(userValues, rbObj);
         break;
       case EvtVarTypeHexInt64:
-        rbObj = ULONG2NUM(pRenderedValues[i].UInt64Val);
-        rbObj = rb_sprintf("%#x", rbObj);
+        rbObj = rb_sprintf("%#I64x", pRenderedValues[i].UInt64Val);
         rb_ary_push(userValues, rbObj);
         break;
       case EvtVarTypeEvtXml:

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -5,25 +5,6 @@
 #include <string>
 #include <vector>
 
-char*
-wstr_to_mbstr(UINT cp, const WCHAR* wstr, int clen)
-{
-  char* ptr;
-  int len = WideCharToMultiByte(cp, 0, wstr, clen, nullptr, 0, nullptr, nullptr);
-  if (!(ptr = static_cast<char*>(xmalloc(len))))
-    return nullptr;
-  WideCharToMultiByte(cp, 0, wstr, clen, ptr, len, nullptr, nullptr);
-
-  return ptr;
-}
-
-void
-free_allocated_mbstr(const char* str)
-{
-  if (str)
-    xfree((char*)str);
-}
-
 VALUE
 wstr_to_rb_str(UINT cp, const WCHAR* wstr, int clen)
 {

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -47,6 +47,13 @@ class WinevtTest < Test::Unit::TestCase
       assert_true(@query.seek(:last))
       assert_true(@query.seek("last"))
     end
+
+    def test_seek_with_invalid_flag
+      error = assert_raises ArgumentError do
+        @query.seek("hoge");
+      end
+      assert_equal("Unknown seek flag: hoge", error.message)
+    end
   end
 
   class BookmarkTest < self


### PR DESCRIPTION
I've added `-Wall` to `CFLAGS` and suppress compile time warnings found by it.
In addition, remove some unused functions.

Some of such warnings are harmless, but some of them cause actual issues.
Please check patches one by one.
