### PR TITLE
query: Handle complex seek flag

### DIFF
--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -35,6 +35,7 @@ VALUE get_values(EVT_HANDLE handle);
 #endif /* __cplusplus */
 
 VALUE rb_cQuery;
+VALUE rb_cFlag;
 VALUE rb_cChannel;
 VALUE rb_cBookmark;
 VALUE rb_cSubscribe;

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -207,6 +207,9 @@ rb_winevt_query_seek(VALUE self, VALUE bookmark_or_flag)
     case T_STRING:
       flag = get_evt_seek_flag_from_cstr(StringValueCStr(bookmark_or_flag));
       break;
+    case T_FIXNUM:
+      flag = NUM2LONG(bookmark_or_flag);
+      break;
     default:
       if (!rb_obj_is_kind_of(bookmark_or_flag, rb_cBookmark))
         rb_raise(rb_eArgError, "Expected a String or a Symbol or a Bookmark instance");
@@ -225,8 +228,9 @@ rb_winevt_query_seek(VALUE self, VALUE bookmark_or_flag)
   } else {
     TypedData_Get_Struct(self, struct WinevtQuery, &rb_winevt_query_type, winevtQuery);
     if (EvtSeek(
-          winevtQuery->query, winevtQuery->offset, NULL, winevtQuery->timeout, flag))
+          winevtQuery->query, winevtQuery->offset, NULL, winevtQuery->timeout, flag)) {
       return Qtrue;
+    }
   }
 
   return Qfalse;
@@ -283,8 +287,17 @@ void
 Init_winevt_query(VALUE rb_cEventLog)
 {
   rb_cQuery = rb_define_class_under(rb_cEventLog, "Query", rb_cObject);
-
   rb_define_alloc_func(rb_cQuery, rb_winevt_query_alloc);
+
+  rb_cFlag = rb_define_module_under(rb_cQuery, "Flag");
+
+  rb_define_const(rb_cFlag, "RelativeToFirst", LONG2NUM(EvtSeekRelativeToFirst));
+  rb_define_const(rb_cFlag, "RelativeToLast", LONG2NUM(EvtSeekRelativeToLast));
+  rb_define_const(rb_cFlag, "RelativeToCurrent", LONG2NUM(EvtSeekRelativeToCurrent));
+  rb_define_const(rb_cFlag, "RelativeToBookmark", LONG2NUM(EvtSeekRelativeToBookmark));
+  rb_define_const(rb_cFlag, "OriginMask", LONG2NUM(EvtSeekOriginMask));
+  rb_define_const(rb_cFlag, "Strict", LONG2NUM(EvtSeekStrict));
+
   rb_define_method(rb_cQuery, "initialize", rb_winevt_query_initialize, 2);
   rb_define_method(rb_cQuery, "next", rb_winevt_query_next, 0);
   rb_define_method(rb_cQuery, "seek", rb_winevt_query_seek, 1);

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -36,15 +36,19 @@ class WinevtTest < Test::Unit::TestCase
       end
     end
 
-    def test_seek
-      assert_true(@query.seek(:first))
-      assert_true(@query.seek("first"))
-      assert_true(@query.seek(:last))
-      assert_true(@query.seek("last"))
-      assert_true(@query.seek(Winevt::EventLog::Query::Flag::RelativeToLast))
-      assert_true(@query.seek(Winevt::EventLog::Query::Flag::RelativeToFirst))
-      assert_true(@query.seek(Winevt::EventLog::Query::Flag::RelativeToFirst |
-                              Winevt::EventLog::Query::Flag::Strict))
+    data("first symbol" => [true, :first],
+         "first string" => [true, "first"],
+         "last symbol" => [true, :last],
+         "last string" => [true, "last"],
+         "Flag::RelativeToLast" => [true, Winevt::EventLog::Query::Flag::RelativeToLast],
+         "Flag::RelativeToFirst" => [true, Winevt::EventLog::Query::Flag::RelativeToFirst],
+         "valid complex Flag" => [true, Winevt::EventLog::Query::Flag::RelativeToFirst |
+                                        Winevt::EventLog::Query::Flag::Strict],
+         "invalid flag" => [false, 123]
+        )
+    def test_seek(data)
+      expected, value = data
+      assert_equal(expected, @query.seek(value))
     end
 
     def test_seek_with_invalid_flag

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -41,6 +41,10 @@ class WinevtTest < Test::Unit::TestCase
       assert_true(@query.seek("first"))
       assert_true(@query.seek(:last))
       assert_true(@query.seek("last"))
+      assert_true(@query.seek(Winevt::EventLog::Query::Flag::RelativeToLast))
+      assert_true(@query.seek(Winevt::EventLog::Query::Flag::RelativeToFirst))
+      assert_true(@query.seek(Winevt::EventLog::Query::Flag::RelativeToFirst |
+                              Winevt::EventLog::Query::Flag::Strict))
     end
 
     def test_seek_with_invalid_flag


### PR DESCRIPTION
Fixes #2 .

The previous implementation does not permit complex seek flag such as:

`EvtSeekRelativeToLast | EvtSeekStrict`

This patch is quite native implementation because the current patch cannot handle why the wrong complex flag values are not accepted.
What should we handle wrong flag circumstances?