### PR TITLE
subscribe: Implement API rate limit feature

### DIFF
--- a/example/rate_limit.rb
+++ b/example/rate_limit.rb
@@ -1,0 +1,14 @@
+require 'winevt'
+
+@subscribe = Winevt::EventLog::Subscribe.new
+@subscribe.tail = true
+@subscribe.rate_limit = 80
+@subscribe.subscribe(
+  "Application", "*[System[(Level <= 4) and TimeCreated[timediff(@SystemTime) <= 86400000]]]"
+)
+while true do
+  @subscribe.each do |eventlog, message, string_inserts|
+    puts ({eventlog: eventlog, data: message})
+  end
+  sleep(0.1)
+end

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -16,6 +16,7 @@
 #endif /* WIN32_WINNT */
 #define _WIN32_WINNT MINIMUM_WINDOWS_VERSION
 
+#include <time.h>
 #include <winevt.h>
 #define EventQuery(object) ((struct WinevtQuery*)DATA_PTR(object))
 #define EventBookMark(object) ((struct WinevtBookmark*)DATA_PTR(object))
@@ -63,6 +64,7 @@ struct WinevtQuery
 };
 
 #define SUBSCRIBE_ARRAY_SIZE 10
+#define SUBSCRIBE_RATE_INFINITE -1
 
 struct WinevtSubscribe
 {
@@ -73,6 +75,9 @@ struct WinevtSubscribe
   DWORD count;
   DWORD flags;
   BOOL tailing;
+  DWORD rateLimit;
+  time_t lastTime;
+  DWORD currentRate;
 };
 
 void Init_winevt_query(VALUE rb_cEventLog);

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -77,7 +77,10 @@ struct WinevtSubscribe
   BOOL tailing;
   DWORD rateLimit;
   time_t lastTime;
+  DWORD previousRate;
   DWORD currentRate;
+  BOOL (*limit_check_handler)(struct WinevtSubscribe*);
+  void (*state_handler)(struct WinevtSubscribe*, ULONG count);
 };
 
 void Init_winevt_query(VALUE rb_cEventLog);

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -79,8 +79,6 @@ struct WinevtSubscribe
   time_t lastTime;
   DWORD previousRate;
   DWORD currentRate;
-  BOOL (*limit_check_handler)(struct WinevtSubscribe*);
-  void (*state_handler)(struct WinevtSubscribe*, ULONG count);
 };
 
 void Init_winevt_query(VALUE rb_cEventLog);

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -77,7 +77,6 @@ struct WinevtSubscribe
   BOOL tailing;
   DWORD rateLimit;
   time_t lastTime;
-  DWORD previousRate;
   DWORD currentRate;
 };
 

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -157,21 +157,18 @@ BOOL
 is_rate_limit_exceeded(struct WinevtSubscribe *winevtSubscribe)
 {
   time_t now;
-  ULONG currRate = 0;
 
   if (winevtSubscribe->rateLimit == SUBSCRIBE_RATE_INFINITE)
     return FALSE;
 
   time(&now);
 
-  winevtSubscribe->previousRate = 0;
-
   if (now <= winevtSubscribe->lastTime) {
-    winevtSubscribe->previousRate = winevtSubscribe->currentRate;
-    currRate = winevtSubscribe->currentRate;
-    if (currRate >= winevtSubscribe->rateLimit) {
+    if (winevtSubscribe->currentRate >= winevtSubscribe->rateLimit) {
       return TRUE;
     }
+  } else {
+    winevtSubscribe->currentRate = 0;
   }
 
   return FALSE;
@@ -181,16 +178,13 @@ void
 update_to_reflect_rate_limit_state(struct WinevtSubscribe *winevtSubscribe, ULONG count)
 {
   time_t lastTime = 0;
-  ULONG currRate = 0;
 
   if (winevtSubscribe->rateLimit == SUBSCRIBE_RATE_INFINITE)
     return;
 
   time(&lastTime);
   winevtSubscribe->lastTime = lastTime;
-  currRate = winevtSubscribe->previousRate;
-  currRate += count;
-  winevtSubscribe->currentRate = currRate;
+  winevtSubscribe->currentRate += count;
 }
 
 static VALUE

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -352,18 +352,21 @@ rb_winevt_subscribe_set_rate_limit(VALUE self, VALUE rb_rate_limit)
   TypedData_Get_Struct(
     self, struct WinevtSubscribe, &rb_winevt_subscribe_type, winevtSubscribe);
 
-  rateLimit = NUM2INT(rb_rate_limit);
+  rateLimit = NUM2LONG(rb_rate_limit);
 
-  if (rateLimit < 10 || (rateLimit % 10)) {
-    rb_raise(rb_eArgError, "Specify a multiples of 10");
-  }
-  winevtSubscribe->rateLimit = rateLimit;
+  if (rateLimit == SUBSCRIBE_RATE_INFINITE) {
+    winevtSubscribe->rateLimit = rateLimit;
 
-  if (winevtSubscribe->rateLimit != SUBSCRIBE_RATE_INFINITE) {
+    winevtSubscribe->limit_check_handler = rate_limit_default_check_handler;
+    winevtSubscribe->state_handler = rate_limit_default_state_handler;
+  } else if (rateLimit < 10 || (rateLimit % 10)) {
+    rb_raise(rb_eArgError, "Specify a multiples of 10 or RATE_INFINITE constant");
+  } else {
+    winevtSubscribe->rateLimit = rateLimit;
+
     winevtSubscribe->limit_check_handler = rate_limit_check_handler;
     winevtSubscribe->state_handler = rate_limit_state_handler;
   }
-
   return Qnil;
 }
 

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -306,11 +306,17 @@ static VALUE
 rb_winevt_subscribe_set_rate_limit(VALUE self, VALUE rb_rate_limit)
 {
   struct WinevtSubscribe* winevtSubscribe;
+  DWORD rateLimit;
 
   TypedData_Get_Struct(
     self, struct WinevtSubscribe, &rb_winevt_subscribe_type, winevtSubscribe);
 
-  winevtSubscribe->rateLimit = NUM2INT(rb_rate_limit);
+  rateLimit = NUM2INT(rb_rate_limit);
+
+  if (rateLimit < 10 || (rateLimit % 10)) {
+    rb_raise(rb_eArgError, "Specify a multiples of 10");
+  }
+  winevtSubscribe->rateLimit = rateLimit;
 
   return Qnil;
 }

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -162,17 +162,20 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
   return Qfalse;
 }
 
-BOOL rate_limit_default_check_handler(struct WinevtSubscribe *winevtSubscribe)
+BOOL
+rate_limit_default_check_handler(struct WinevtSubscribe *winevtSubscribe)
 {
   return FALSE;
 }
 
-void rate_limit_default_state_handler(struct WinevtSubscribe *winevtSubscribe,
-                                      ULONG count)
+void
+rate_limit_default_state_handler(struct WinevtSubscribe *winevtSubscribe,
+                                 ULONG count)
 {
 }
 
-BOOL rate_limit_check_handler(struct WinevtSubscribe *winevtSubscribe)
+BOOL
+rate_limit_check_handler(struct WinevtSubscribe *winevtSubscribe)
 {
   time_t now;
   ULONG currRate = 0;
@@ -192,7 +195,8 @@ BOOL rate_limit_check_handler(struct WinevtSubscribe *winevtSubscribe)
   return FALSE;
 }
 
-void rate_limit_state_handler(struct WinevtSubscribe *winevtSubscribe, ULONG count)
+void
+rate_limit_state_handler(struct WinevtSubscribe *winevtSubscribe, ULONG count)
 {
   time_t lastTime = 0;
   ULONG currRate = 0;

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -154,7 +154,7 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
 }
 
 BOOL
-rate_limit_check_handler(struct WinevtSubscribe *winevtSubscribe)
+is_rate_limit_exceeded(struct WinevtSubscribe *winevtSubscribe)
 {
   time_t now;
   ULONG currRate = 0;
@@ -178,7 +178,7 @@ rate_limit_check_handler(struct WinevtSubscribe *winevtSubscribe)
 }
 
 void
-rate_limit_state_handler(struct WinevtSubscribe *winevtSubscribe, ULONG count)
+rate_limit_state(struct WinevtSubscribe *winevtSubscribe, ULONG count)
 {
   time_t lastTime = 0;
   ULONG currRate = 0;
@@ -204,7 +204,7 @@ rb_winevt_subscribe_next(VALUE self)
   TypedData_Get_Struct(
     self, struct WinevtSubscribe, &rb_winevt_subscribe_type, winevtSubscribe);
 
-  if (rate_limit_check_handler(winevtSubscribe)) {
+  if (is_rate_limit_exceeded(winevtSubscribe)) {
     return Qfalse;
   }
 
@@ -223,7 +223,7 @@ rb_winevt_subscribe_next(VALUE self)
       EvtUpdateBookmark(winevtSubscribe->bookmark, winevtSubscribe->hEvents[i]);
     }
 
-    rate_limit_state_handler(winevtSubscribe, count);
+    rate_limit_state(winevtSubscribe, count);
 
     return Qtrue;
   }

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -178,7 +178,7 @@ is_rate_limit_exceeded(struct WinevtSubscribe *winevtSubscribe)
 }
 
 void
-rate_limit_state(struct WinevtSubscribe *winevtSubscribe, ULONG count)
+update_to_reflect_rate_limit_state(struct WinevtSubscribe *winevtSubscribe, ULONG count)
 {
   time_t lastTime = 0;
   ULONG currRate = 0;
@@ -223,7 +223,7 @@ rb_winevt_subscribe_next(VALUE self)
       EvtUpdateBookmark(winevtSubscribe->bookmark, winevtSubscribe->hEvents[i]);
     }
 
-    rate_limit_state(winevtSubscribe, count);
+    update_to_reflect_rate_limit_state(winevtSubscribe, count);
 
     return Qtrue;
   }

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -123,6 +123,14 @@ class WinevtTest < Test::Unit::TestCase
         @subscribe.respond_to?(:each)
       end
     end
+
+    def test_rate_limit
+      assert_equal(Winevt::EventLog::Subscribe::RATE_INFINITE,
+                   @subscribe.rate_limit)
+      rate_limit = 50
+      @subscribe.rate_limit = rate_limit
+      assert_equal(rate_limit, @subscribe.rate_limit)
+    end
   end
 
   class ChannelTest < self

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -130,6 +130,12 @@ class WinevtTest < Test::Unit::TestCase
       rate_limit = 50
       @subscribe.rate_limit = rate_limit
       assert_equal(rate_limit, @subscribe.rate_limit)
+      assert_raise(ArgumentError) do
+        @subscribe.rate_limit = 3
+      end
+      assert_raise(ArgumentError) do
+        @subscribe.rate_limit = 33
+      end
     end
   end
 

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -130,6 +130,9 @@ class WinevtTest < Test::Unit::TestCase
       rate_limit = 50
       @subscribe.rate_limit = rate_limit
       assert_equal(rate_limit, @subscribe.rate_limit)
+      @subscribe.rate_limit = Winevt::EventLog::Subscribe::RATE_INFINITE
+      assert_equal(Winevt::EventLog::Subscribe::RATE_INFINITE,
+                   @subscribe.rate_limit)
       assert_raise(ArgumentError) do
         @subscribe.rate_limit = 3
       end


### PR DESCRIPTION
I've implemented a naive rate limit feature.
This feature should be disabled by default.