### PR TITLE
Add missing error handlings for rb_winevt_subscribe_subscribe()

### DIFF
--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -27,6 +27,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 VALUE wstr_to_rb_str(UINT cp, const WCHAR* wstr, int clen);
+void  raise_system_error(VALUE error, DWORD errorCode);
 VALUE render_to_rb_str(EVT_HANDLE handle, DWORD flags);
 WCHAR* get_description(EVT_HANDLE handle);
 VALUE get_values(EVT_HANDLE handle);

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -186,6 +186,10 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
 
   hSubscription =
     EvtSubscribe(NULL, hSignalEvent, path, query, hBookmark, NULL, NULL, flags);
+  if (!hSubscription) {
+    status = GetLastError();
+    raise_system_error(rb_eWinevtQueryError, status);
+  }
 
   ALLOCV_END(wpathBuf);
   ALLOCV_END(wqueryBuf);
@@ -196,14 +200,13 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
     winevtSubscribe->bookmark = hBookmark;
   } else {
     winevtSubscribe->bookmark = EvtCreateBookmark(NULL);
+    if (winevtSubscribe->bookmark == NULL) {
+      status = GetLastError();
+      raise_system_error(rb_eWinevtQueryError, status);
+    }
   }
 
-  status = GetLastError();
-
-  if (status == ERROR_SUCCESS)
-    return Qtrue;
-
-  return Qfalse;
+  return Qtrue;
 }
 
 BOOL

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -19,6 +19,28 @@ wstr_to_rb_str(UINT cp, const WCHAR* wstr, int clen)
   return str;
 }
 
+void
+raise_system_error(VALUE error, DWORD errorCode)
+{
+  WCHAR msgBuf[256];
+  VALUE errorMessage;
+
+  FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                 NULL,
+                 errorCode,
+                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                 msgBuf,
+                 _countof(msgBuf),
+                 NULL);
+  errorMessage = wstr_to_rb_str(CP_UTF8, msgBuf, -1);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat="
+#pragma GCC diagnostic ignored "-Wformat-extra-args"
+  rb_raise(error, "ErrorCode: %lu\nError: %" PRIsVALUE "\n", errorCode, errorMessage);
+#pragma GCC diagnostic pop
+}
+
 VALUE
 render_to_rb_str(EVT_HANDLE handle, DWORD flags)
 {

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -22,7 +22,7 @@ wstr_to_rb_str(UINT cp, const WCHAR* wstr, int clen)
 void
 raise_system_error(VALUE error, DWORD errorCode)
 {
-  WCHAR msgBuf[256];
+  WCHAR msgBuf[256] = { 0 };
   VALUE errorMessage;
 
   FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -117,6 +117,14 @@ class WinevtTest < Test::Unit::TestCase
       assert_true(subscribe.next)
     end
 
+    def test_subscribe_invalid_query
+      subscribe = Winevt::EventLog::Subscribe.new
+      error = assert_raises Winevt::EventLog::Query::Error do
+        subscribe.subscribe("", "");
+      end
+      assert_match(/ErrorCode: 15001\nError: .*\n/, error.message)
+    end
+
     def test_next
       assert_true(@subscribe.next)
     end


### PR DESCRIPTION
In the previous code GetLastError() may not be called for
EvtSubscribe().

In addition, the error message isn't internationalized since
FormatMessageA() was used. This commit replaces it with
FormatMessageW().

Other error handlings should use FormatMessageW() too, so I'll replace
them later.