### PR TITLE
Create Bookmark handle in #subscribe safely

### DIFF
--- a/lib/winevt.rb
+++ b/lib/winevt.rb
@@ -3,6 +3,7 @@ begin
 rescue LoadError
   require "winevt/winevt"
 end
+require "winevt/bookmark"
 require "winevt/query"
 require "winevt/subscribe"
 require "winevt/version"

--- a/lib/winevt/bookmark.rb
+++ b/lib/winevt/bookmark.rb
@@ -1,0 +1,6 @@
+module Winevt
+  class EventLog
+    class Bookmark
+    end
+  end
+end

--- a/lib/winevt/subscribe.rb
+++ b/lib/winevt/subscribe.rb
@@ -1,6 +1,15 @@
 module Winevt
   class EventLog
     class Subscribe
+      alias_method :subscribe_raw, :subscribe
+
+      def subscribe(path, query, bookmark = nil)
+        if bookmark.is_a?(Winevt::EventLog::Bookmark)
+          subscribe_raw(path, query, bookmark.render)
+        else
+          subscribe_raw(path, query)
+        end
+      end
     end
   end
 end

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -111,6 +111,12 @@ class WinevtTest < Test::Unit::TestCase
       end
     end
 
+    def test_subscribe_with_bookmark
+      subscribe = Winevt::EventLog::Subscribe.new
+      subscribe.subscribe("Application", "*", @bookmark)
+      assert_true(subscribe.next)
+    end
+
     def test_subscribe_without_bookmark
       subscribe = Winevt::EventLog::Subscribe.new
       subscribe.subscribe("Application", "*")


### PR DESCRIPTION
In the previous implementation, Bookmark instance may be double freed.
In Subscribe class, Bookmark handle should be created from Bookmark XML.
But existing API should not break.