### PR TITLE
Build fat gem with rake-compiler-dock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+rvm:
+  - 2.4
+
+services:
+  - docker
+
+gemfile:
+  - Gemfile
+
+before_install:
+  - gem update --system=2.7.8
+
+script:
+  - bundle exec rake gem:native


### PR DESCRIPTION
Nowadays, fat gem should be deprecated but td-agent users usually do not
have MSYS2 system in their production/staging environment.
We still need to maintenance fat gem building process.