### PR TITLE
Fix invalid bookmark XML string render handling

### DIFF
--- a/lib/winevt/subscribe.rb
+++ b/lib/winevt/subscribe.rb
@@ -2,10 +2,23 @@ module Winevt
   class EventLog
     class Subscribe
       alias_method :subscribe_raw, :subscribe
+      alias_method :initialize_raw, :initialize
+      attr_reader :query_error
+
+      def initialize
+        @query_error = nil
+        initialize_raw
+      end
 
       def subscribe(path, query, bookmark = nil)
         if bookmark.is_a?(Winevt::EventLog::Bookmark)
-          subscribe_raw(path, query, bookmark.render)
+          begin
+            subscribe_raw(path, query, bookmark.render)
+          rescue Winevt::EventLog::Query::Error => e
+            @query_error = e
+            # fallback to without bookmark version.
+            subscribe_raw(path, query)
+          end
         else
           subscribe_raw(path, query)
         end

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -117,6 +117,15 @@ class WinevtTest < Test::Unit::TestCase
       assert_true(subscribe.next)
     end
 
+    INVALID_XML = "<broken>"
+    def test_subscribe_with_invalid_bookmark
+      subscribe = Winevt::EventLog::Subscribe.new
+      bookmark = Winevt::EventLog::Bookmark.new(INVALID_XML)
+      subscribe.subscribe("Application", "*", bookmark)
+      assert_match(/ErrorCode: 6\nError: .*\n/, subscribe.query_error.message)
+      assert_true(subscribe.next)
+    end
+
     def test_subscribe_without_bookmark
       subscribe = Winevt::EventLog::Subscribe.new
       subscribe.subscribe("Application", "*")


### PR DESCRIPTION
The previous bookmark XML string handling code has a bit of problem.
The default configuration of fluent-plugin-windows-eventlog causes testcases failures:
https://ci.appveyor.com/project/fluent/fluent-plugin-windows-eventlog/builds/28479716/job/u8ju2l12opd8kgrw

This should be fixed in winevt_c.