### PR TITLE
Plug memory leaks in subscribe#subscribe in mainly error handling cases

### DIFF
--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -205,6 +205,9 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
   if (!hSubscription) {
     status = GetLastError();
     raise_system_error(rb_eWinevtQueryError, status);
+  } else if (winevtSubscribe->subscription != NULL) {
+    // should be disgarded the old event subscription handle.
+    EvtClose(winevtSubscribe->subscription);
   }
 
   ALLOCV_END(wpathBuf);

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -211,7 +211,9 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
     }
     status = GetLastError();
     raise_system_error(rb_eWinevtQueryError, status);
-  } else if (winevtSubscribe->subscription != NULL) {
+  }
+
+  if (winevtSubscribe->subscription != NULL) {
     // should be disgarded the old event subscription handle.
     EvtClose(winevtSubscribe->subscription);
   }

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -203,6 +203,12 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
   hSubscription =
     EvtSubscribe(NULL, hSignalEvent, path, query, hBookmark, NULL, NULL, flags);
   if (!hSubscription) {
+    if (hBookmark != NULL) {
+      EvtClose(hBookmark);
+    }
+    if (hSignalEvent != NULL) {
+      CloseHandle(hSignalEvent);
+    }
     status = GetLastError();
     raise_system_error(rb_eWinevtQueryError, status);
   } else if (winevtSubscribe->subscription != NULL) {
@@ -220,6 +226,12 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
   } else {
     winevtSubscribe->bookmark = EvtCreateBookmark(NULL);
     if (winevtSubscribe->bookmark == NULL) {
+      if (hSubscription != NULL) {
+        EvtClose(hSubscription);
+      }
+      if (hSignalEvent != NULL) {
+        CloseHandle(hSignalEvent);
+      }
       status = GetLastError();
       raise_system_error(rb_eWinevtQueryError, status);
     }

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -111,6 +111,14 @@ class WinevtTest < Test::Unit::TestCase
       end
     end
 
+    def test_subscribe_twice
+      subscribe = Winevt::EventLog::Subscribe.new
+      subscribe.subscribe("Application", "*")
+      assert_true(subscribe.next)
+      subscribe.subscribe("Security", "*")
+      assert_true(subscribe.next)
+    end
+
     def test_subscribe_with_bookmark
       subscribe = Winevt::EventLog::Subscribe.new
       subscribe.subscribe("Application", "*", @bookmark)


### PR DESCRIPTION
* Discard previous subscription member handle
* Should close subscribe, bookmark, and signal event handles before raising exception