### PR TITLE
Check subscribable type for channel

### DIFF
--- a/example/enumerate_channels.rb
+++ b/example/enumerate_channels.rb
@@ -1,0 +1,13 @@
+require 'winevt'
+
+@channels = Winevt::EventLog::Channel.new
+@channels.force_enumerate = false
+result = []
+@channels.each do |channel|
+  result << channel
+end
+
+puts "length of channels: #{result.length}"
+result.each do |r|
+  puts r
+end

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -47,6 +47,7 @@ VALUE rb_eWinevtQueryError;
 struct WinevtChannel
 {
   EVT_HANDLE channels;
+  BOOL force_enumerate;
 };
 
 struct WinevtBookmark

--- a/ext/winevt/winevt_channel.c
+++ b/ext/winevt/winevt_channel.c
@@ -17,6 +17,8 @@
  *  print channels
  */
 
+DWORD is_subscribable_channel_p(EVT_HANDLE hChannel, BOOL force_enumerate);
+DWORD check_subscribable_with_channel_config_type(int Id, PEVT_VARIANT pProperty, BOOL force_enumerate);
 static void channel_free(void* ptr);
 
 static const rb_data_type_t rb_winevt_channel_type = { "winevt/channel",
@@ -103,9 +105,6 @@ rb_winevt_channel_get_force_enumerate(VALUE self)
 
   return winevtChannel->force_enumerate ? Qtrue : Qfalse;
 }
-
-DWORD is_subscribable_channel_p(EVT_HANDLE hChannel, BOOL force_enumerate);
-DWORD check_subscribable_with_channel_config_type(int Id, PEVT_VARIANT pProperty, BOOL force_enumerate);
 
 DWORD is_subscribable_channel_p(EVT_HANDLE hChannel, BOOL force_enumerate)
 {

--- a/ext/winevt/winevt_channel.c
+++ b/ext/winevt/winevt_channel.c
@@ -59,6 +59,68 @@ rb_winevt_channel_initialize(VALUE klass)
   return Qnil;
 }
 
+DWORD is_subscribable_channel_p(EVT_HANDLE hChannel);
+DWORD check_subscribable_with_channel_config_type(int Id, PEVT_VARIANT pProperty);
+
+DWORD is_subscribable_channel_p(EVT_HANDLE hChannel)
+{
+  PEVT_VARIANT pProperty = NULL;
+  PEVT_VARIANT pTemp = NULL;
+  DWORD dwBufferSize = 0;
+  DWORD dwBufferUsed = 0;
+  DWORD status = ERROR_SUCCESS;
+
+  for (int Id = 0; Id < EvtChannelConfigPropertyIdEND; Id++) {
+    if  (!EvtGetChannelConfigProperty(hChannel, (EVT_CHANNEL_CONFIG_PROPERTY_ID)Id, 0, dwBufferSize, pProperty, &dwBufferUsed)) {
+      status = GetLastError();
+      if (ERROR_INSUFFICIENT_BUFFER == status) {
+        dwBufferSize = dwBufferUsed;
+        pTemp = (PEVT_VARIANT)realloc(pProperty, dwBufferSize);
+        if (pTemp) {
+          pProperty = pTemp;
+          pTemp = NULL;
+          EvtGetChannelConfigProperty(hChannel, (EVT_CHANNEL_CONFIG_PROPERTY_ID)Id, 0, dwBufferSize, pProperty, &dwBufferUsed);
+        } else {
+          free(pProperty);
+          status = ERROR_OUTOFMEMORY;
+          rb_raise(rb_eRuntimeError, "realloc failed with %ld\n", status);
+        }
+      }
+
+      if (ERROR_SUCCESS != (status = GetLastError())) {
+        free(pProperty);
+        rb_raise(rb_eRuntimeError, "EvtGetChannelConfigProperty failed with %ld\n", GetLastError());
+      }
+    }
+
+    status = check_subscribable_with_channel_config_type(Id, pProperty);
+    if (status != ERROR_SUCCESS)
+      break;
+  }
+
+  return status;
+}
+
+#define EVENT_DEBUG_TYPE 2
+#define EVENT_ANALYTICAL_TYPE 3
+
+DWORD check_subscribable_with_channel_config_type(int Id, PEVT_VARIANT pProperty)
+{
+  DWORD status = ERROR_SUCCESS;
+  switch(Id) {
+  case EvtChannelConfigType:
+    if (pProperty->UInt32Val == EVENT_DEBUG_TYPE || pProperty->UInt32Val == EVENT_ANALYTICAL_TYPE) {
+      return ERROR_INVALID_DATA;
+    }
+    break;
+  }
+
+  return status;
+}
+
+#undef EVENT_DEBUG_TYPE
+#undef EVENT_ANALYTICAL_TYPE
+
 /*
  * Enumerate Windows EventLog channels
  *
@@ -69,6 +131,7 @@ static VALUE
 rb_winevt_channel_each(VALUE self)
 {
   EVT_HANDLE hChannels;
+  EVT_HANDLE hChannelConfig = NULL;
   struct WinevtChannel* winevtChannel;
   char errBuf[256];
   LPWSTR buffer = NULL;
@@ -124,6 +187,23 @@ rb_winevt_channel_each(VALUE self)
         rb_raise(rb_eRuntimeError, errBuf);
       }
     }
+    hChannelConfig = EvtOpenChannelConfig(NULL, buffer, 0);
+    if (NULL == hChannelConfig) {
+      _snprintf_s(errBuf,
+                  _countof(errBuf),
+                  _TRUNCATE,
+                  "EvtOpenChannelConfig failed with %lu.\n",
+                  GetLastError());
+      free(buffer);
+      buffer = NULL;
+      bufferSize = 0;
+
+      rb_raise(rb_eRuntimeError, errBuf);
+    }
+
+    status = is_subscribable_channel_p(hChannelConfig);
+    if (status != ERROR_SUCCESS)
+      continue;
 
     utf8str = wstr_to_rb_str(CP_UTF8, buffer, -1);
 

--- a/ext/winevt/winevt_channel.c
+++ b/ext/winevt/winevt_channel.c
@@ -126,8 +126,7 @@ DWORD is_subscribable_channel_p(EVT_HANDLE hChannel, BOOL force_enumerate)
           pTemp = NULL;
           EvtGetChannelConfigProperty(hChannel, (EVT_CHANNEL_CONFIG_PROPERTY_ID)Id, 0, dwBufferSize, pProperty, &dwBufferUsed);
         } else {
-          if (pProperty)
-            free(pProperty);
+          free(pProperty);
 
           status = ERROR_OUTOFMEMORY;
           rb_raise(rb_eRuntimeError, "realloc failed with %ld\n", status);
@@ -135,8 +134,7 @@ DWORD is_subscribable_channel_p(EVT_HANDLE hChannel, BOOL force_enumerate)
       }
 
       if (ERROR_SUCCESS != (status = GetLastError())) {
-        if (pProperty)
-          free(pProperty);
+        free(pProperty);
 
         rb_raise(rb_eRuntimeError, "EvtGetChannelConfigProperty failed with %ld\n", GetLastError());
       }
@@ -147,8 +145,7 @@ DWORD is_subscribable_channel_p(EVT_HANDLE hChannel, BOOL force_enumerate)
       break;
   }
 
-  if (pProperty)
-    free(pProperty);
+  free(pProperty);
 
   return status;
 }

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -194,5 +194,11 @@ class WinevtTest < Test::Unit::TestCase
         @channel.each
       end
     end
+
+    def test_force_enumerate
+      assert_false(@channel.force_enumerate)
+      @channel.force_enumerate = true
+      assert_true(@channel.force_enumerate)
+    end
   end
 end


### PR DESCRIPTION
This feature is needed for enumerating all subscribable channel.

Based on these lines' idea:
https://github.com/PowerShell/PowerShell/blob/master/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs#L627-L633

Debug and Analytical type of channel are not subscribable.

Related to https://github.com/fluent/fluent-plugin-windows-eventlog/issues/47, https://github.com/fluent/fluent-plugin-windows-eventlog/pull/48#discussion_r384901296.