### PR TITLE
Fix building error with mingw-w64 gcc 10.1

### DIFF
--- a/ext/winevt/winevt.c
+++ b/ext/winevt/winevt.c
@@ -1,7 +1,10 @@
 #include <winevt_c.h>
 
 VALUE rb_mWinevt;
+VALUE rb_cQuery;
 VALUE rb_cEventLog;
+VALUE rb_cSubscribe;
+VALUE rb_eWinevtQueryError;
 
 static ID id_call;
 

--- a/ext/winevt/winevt_bookmark.c
+++ b/ext/winevt/winevt_bookmark.c
@@ -19,6 +19,8 @@
  */
 /* clang-format pn */
 
+VALUE rb_cBookmark;
+
 static void bookmark_free(void* ptr);
 
 static const rb_data_type_t rb_winevt_bookmark_type = { "winevt/bookmark",

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -40,12 +40,12 @@ VALUE render_system_event(EVT_HANDLE handle, BOOL preserve_qualifiers);
 }
 #endif /* __cplusplus */
 
-VALUE rb_cQuery;
-VALUE rb_cFlag;
-VALUE rb_cChannel;
-VALUE rb_cBookmark;
-VALUE rb_cSubscribe;
-VALUE rb_eWinevtQueryError;
+extern VALUE rb_cQuery;
+extern VALUE rb_cFlag;
+extern VALUE rb_cChannel;
+extern VALUE rb_cBookmark;
+extern VALUE rb_cSubscribe;
+extern VALUE rb_eWinevtQueryError;
 
 struct WinevtChannel
 {

--- a/ext/winevt/winevt_channel.c
+++ b/ext/winevt/winevt_channel.c
@@ -19,6 +19,8 @@
  *  print channels
  */
 
+VALUE rb_cChannel;
+
 DWORD is_subscribable_channel_p(EVT_HANDLE hChannel, BOOL force_enumerate);
 DWORD check_subscribable_with_channel_config_type(int Id, PEVT_VARIANT pProperty, BOOL force_enumerate);
 static void channel_free(void* ptr);

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -17,6 +17,7 @@
  */
 /* clang-format on */
 
+VALUE rb_cFlag;
 
 static void query_free(void* ptr);
 


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

`winevt_c` gem also should be fixed like as `certstore_c` gem....