### PR TITLE
Handle invalid locale as ArgmentError exception

### DIFF
--- a/ext/winevt/winevt_locale.c
+++ b/ext/winevt/winevt_locale.c
@@ -64,5 +64,5 @@ get_locale_from_rb_str(VALUE rb_locale_str)
     }
   }
 
-  return &default_locale;
+  rb_raise(rb_eArgError, "Unknown locale: %s", locale_str);
 }

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -88,8 +88,9 @@ class WinevtTest < Test::Unit::TestCase
 
     def test_invalid_locale
       assert_equal("neutral", @query.locale)
-      @query.locale = "ex_EX" # Invalid Locale
-      assert_equal("neutral", @query.locale)
+      assert_raise(ArgumentError) do
+        @query.locale = "ex_EX" # Invalid Locale
+      end
     end
   end
 
@@ -246,8 +247,9 @@ class WinevtTest < Test::Unit::TestCase
 
     def test_invalid_locale
       assert_equal("neutral", @subscribe.locale)
-      @subscribe.locale = "ex_EX" # Invalid Locale
-      assert_equal("neutral", @subscribe.locale)
+      assert_raise(ArgumentError) do
+        @subscribe.locale = "ex_EX" # Invalid Locale
+      end
     end
   end
 


### PR DESCRIPTION
For using Fluentd plugin, specifying invalid locale should be notified as exception.
In Fluentd side, invalid configuration should notify as exception.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>
