### PR TITLE
Implement remoting Windows EventLog access

### DIFF
--- a/example/eventlog.rb
+++ b/example/eventlog.rb
@@ -1,7 +1,6 @@
 require 'winevt'
 
-@session = Winevt::EventLog::Session.new
-@session.server = "127.0.0.1" # Or remote box ip
+@session = Winevt::EventLog::Session.new("127.0.0.1") # Or remote box ip
 # @session.domain = "<EXAMPLEGROUP>"
 # @session.username = "<username>"
 # @session.password = "<password>"

--- a/example/eventlog.rb
+++ b/example/eventlog.rb
@@ -1,6 +1,11 @@
 require 'winevt'
 
-@query = Winevt::EventLog::Query.new("Application", "*[System[(Level <= 3) and TimeCreated[timediff(@SystemTime) <= 86400000]]]")
+@session = Winevt::EventLog::Session.new
+@session.server = "127.0.0.1" # Or remote box ip
+# @session.domain = "<EXAMPLEGROUP>"
+# @session.username = "<username>"
+# @session.password = "<password>"
+@query = Winevt::EventLog::Query.new("Application", "*[System[(Level <= 4) and TimeCreated[timediff(@SystemTime) <= 86400000]]]", @session)
 
 @query.render_as_xml = true
 @query.preserve_qualifiers = true

--- a/example/tailing.rb
+++ b/example/tailing.rb
@@ -1,7 +1,6 @@
 require 'winevt'
 
-@session = Winevt::EventLog::Session.new
-@session.server = "127.0.0.1" # Or remote box ip
+@session = Winevt::EventLog::Session.new("127.0.0.1") # Or remote box ip
 # @session.domain = "<EXAMPLEGROUP>"
 # @session.username = "<username>"
 # @session.password = "<password>"

--- a/example/tailing.rb
+++ b/example/tailing.rb
@@ -1,11 +1,18 @@
 require 'winevt'
 
+@session = Winevt::EventLog::Session.new
+@session.server = "127.0.0.1" # Or remote box ip
+# @session.domain = "<EXAMPLEGROUP>"
+# @session.username = "<username>"
+# @session.password = "<password>"
+@bookmark = Winevt::EventLog::Bookmark.new
 @subscribe = Winevt::EventLog::Subscribe.new
 @subscribe.read_existing_events = true
 @subscribe.preserve_qualifiers = true
 @subscribe.render_as_xml = true
 @subscribe.subscribe(
-  "Security", "*[System[(Level <= 4) and TimeCreated[timediff(@SystemTime) <= 86400000]]]"
+  "Security", "*[System[(Level <= 4) and TimeCreated[timediff(@SystemTime) <= 86400000]]]",
+  @bookmark, @session
 )
 while true do
   @subscribe.each do |eventlog, message, string_inserts|

--- a/ext/winevt/winevt.c
+++ b/ext/winevt/winevt.c
@@ -5,6 +5,7 @@ VALUE rb_cQuery;
 VALUE rb_cEventLog;
 VALUE rb_cSubscribe;
 VALUE rb_eWinevtQueryError;
+VALUE rb_eRemoteHandlerError;
 
 static ID id_call;
 
@@ -16,6 +17,7 @@ Init_winevt(void)
   rb_cQuery = rb_define_class_under(rb_cEventLog, "Query", rb_cObject);
   rb_cSubscribe = rb_define_class_under(rb_cEventLog, "Subscribe", rb_cObject);
   rb_eWinevtQueryError = rb_define_class_under(rb_cQuery, "Error", rb_eStandardError);
+  rb_eRemoteHandlerError = rb_define_class_under(rb_cSubscribe, "RemoteHandlerError", rb_eRuntimeError);
 
   Init_winevt_channel(rb_cEventLog);
   Init_winevt_bookmark(rb_cEventLog);

--- a/ext/winevt/winevt.c
+++ b/ext/winevt/winevt.c
@@ -22,6 +22,7 @@ Init_winevt(void)
   Init_winevt_query(rb_cEventLog);
   Init_winevt_subscribe(rb_cEventLog);
   Init_winevt_locale(rb_cEventLog);
+  Init_winevt_session(rb_cEventLog);
 
   id_call = rb_intern("call");
 }

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -21,6 +21,7 @@
 #define EventQuery(object) ((struct WinevtQuery*)DATA_PTR(object))
 #define EventBookMark(object) ((struct WinevtBookmark*)DATA_PTR(object))
 #define EventChannel(object) ((struct WinevtChannel*)DATA_PTR(object))
+#define EventSession(object) ((struct WinevtSession*)DATA_PTR(object))
 
 typedef struct {
   LANGID langID;
@@ -54,6 +55,14 @@ extern VALUE rb_cBookmark;
 extern VALUE rb_cSubscribe;
 extern VALUE rb_eWinevtQueryError;
 extern VALUE rb_cLocale;
+extern VALUE rb_cSession;
+
+struct WinevtSession {
+  WCHAR* computerName;
+  WCHAR* domain;
+  WCHAR* username;
+  WCHAR* password;
+};
 
 extern LocaleInfo localeInfoTable[];
 extern LocaleInfo default_locale;
@@ -111,5 +120,6 @@ void Init_winevt_channel(VALUE rb_cEventLog);
 void Init_winevt_bookmark(VALUE rb_cEventLog);
 void Init_winevt_subscribe(VALUE rb_cEventLog);
 void Init_winevt_locale(VALUE rb_cEventLog);
+void Init_winevt_session(VALUE rb_cEventLog);
 
 #endif // _WINEVT_C_H

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -40,7 +40,8 @@ VALUE wstr_to_rb_str(UINT cp, const WCHAR* wstr, int clen);
 void  raise_system_error(VALUE error, DWORD errorCode);
 VALUE render_to_rb_str(EVT_HANDLE handle, DWORD flags);
 EVT_HANDLE connect_to_remote(LPWSTR computerName, LPWSTR domain,
-                             LPWSTR username, LPWSTR password);
+                             LPWSTR username, LPWSTR password,
+                             EVT_RPC_LOGIN_FLAGS flags);
 WCHAR* get_description(EVT_HANDLE handle, LANGID langID, EVT_HANDLE hRemote);
 VALUE get_values(EVT_HANDLE handle);
 VALUE render_system_event(EVT_HANDLE handle, BOOL preserve_qualifiers);

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -39,8 +39,8 @@ VALUE wstr_to_rb_str(UINT cp, const WCHAR* wstr, int clen);
 #endif /* __cplusplus */
 void  raise_system_error(VALUE error, DWORD errorCode);
 VALUE render_to_rb_str(EVT_HANDLE handle, DWORD flags);
-EVT_HANDLE connect_to_remote(WCHAR* computerName, WCHAR* domain,
-                             WCHAR* username, WCHAR* password);
+EVT_HANDLE connect_to_remote(LPWSTR computerName, LPWSTR domain,
+                             LPWSTR username, LPWSTR password);
 WCHAR* get_description(EVT_HANDLE handle, LANGID langID, EVT_HANDLE hRemote);
 VALUE get_values(EVT_HANDLE handle);
 VALUE render_system_event(EVT_HANDLE handle, BOOL preserve_qualifiers);
@@ -60,10 +60,10 @@ extern VALUE rb_cLocale;
 extern VALUE rb_cSession;
 
 struct WinevtSession {
-  WCHAR* computerName;
-  WCHAR* domain;
-  WCHAR* username;
-  WCHAR* password;
+  LPWSTR server;
+  LPWSTR domain;
+  LPWSTR username;
+  LPWSTR password;
 };
 
 extern LocaleInfo localeInfoTable[];

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -41,7 +41,7 @@ void  raise_system_error(VALUE error, DWORD errorCode);
 VALUE render_to_rb_str(EVT_HANDLE handle, DWORD flags);
 EVT_HANDLE connect_to_remote(WCHAR* computerName, WCHAR* domain,
                              WCHAR* username, WCHAR* password);
-WCHAR* get_description(EVT_HANDLE handle, LANGID langID);
+WCHAR* get_description(EVT_HANDLE handle, LANGID langID, EVT_HANDLE hRemote);
 VALUE get_values(EVT_HANDLE handle);
 VALUE render_system_event(EVT_HANDLE handle, BOOL preserve_qualifiers);
 LocaleInfo* get_locale_info_from_rb_str(VALUE rb_locale_str);

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -39,6 +39,8 @@ VALUE wstr_to_rb_str(UINT cp, const WCHAR* wstr, int clen);
 #endif /* __cplusplus */
 void  raise_system_error(VALUE error, DWORD errorCode);
 VALUE render_to_rb_str(EVT_HANDLE handle, DWORD flags);
+EVT_HANDLE connect_to_remote(WCHAR* computerName, WCHAR* domain,
+                             WCHAR* username, WCHAR* password);
 WCHAR* get_description(EVT_HANDLE handle, LANGID langID);
 VALUE get_values(EVT_HANDLE handle);
 VALUE render_system_event(EVT_HANDLE handle, BOOL preserve_qualifiers);

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -64,6 +64,7 @@ struct WinevtSession {
   LPWSTR domain;
   LPWSTR username;
   LPWSTR password;
+  EVT_RPC_LOGIN_FLAGS flags;
 };
 
 extern LocaleInfo localeInfoTable[];

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -57,6 +57,7 @@ extern VALUE rb_cChannel;
 extern VALUE rb_cBookmark;
 extern VALUE rb_cSubscribe;
 extern VALUE rb_eWinevtQueryError;
+extern VALUE rb_eRemoteHandlerError;
 extern VALUE rb_cLocale;
 extern VALUE rb_cSession;
 

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -95,6 +95,7 @@ struct WinevtQuery
   BOOL renderAsXML;
   BOOL preserveQualifiers;
   LocaleInfo *localeInfo;
+  EVT_HANDLE remoteHandle;
 };
 
 #define SUBSCRIBE_ARRAY_SIZE 10

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -116,6 +116,7 @@ struct WinevtSubscribe
   BOOL renderAsXML;
   BOOL preserveQualifiers;
   LocaleInfo* localeInfo;
+  EVT_HANDLE remoteHandle;
 };
 
 void Init_winevt_query(VALUE rb_cEventLog);

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -90,9 +90,10 @@ rb_winevt_query_initialize(VALUE argc, VALUE* argv, VALUE self)
                                       winevtSession->domain,
                                       winevtSession->username,
                                       winevtSession->password);
+
     err = GetLastError();
     if (err != ERROR_SUCCESS) {
-      rb_raise(rb_eArgError, "Cannot authorize remote server. Error: %ld", err);
+      raise_system_error(rb_eRuntimeError, err);
     }
   }
 

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -77,17 +77,23 @@ rb_winevt_query_initialize(VALUE argc, VALUE* argv, VALUE self)
   EVT_HANDLE hRemoteHandle = NULL;
   DWORD len;
   VALUE wchannelBuf, wpathBuf;
+  DWORD err;
 
   rb_scan_args(argc, argv, "21", &channel, &xpath, &session);
   Check_Type(channel, T_STRING);
   Check_Type(xpath, T_STRING);
 
   if (rb_obj_is_kind_of(session, rb_cSession)) {
-    winevtSession = EventSession(rb_cSession);
-    hRemoteHandle = connect_to_remote(winevtSession->computerName,
+    winevtSession = EventSession(session);
+
+    hRemoteHandle = connect_to_remote(winevtSession->server,
                                       winevtSession->domain,
                                       winevtSession->username,
                                       winevtSession->password);
+    err = GetLastError();
+    if (err != ERROR_SUCCESS) {
+      rb_raise(rb_eArgError, "Cannot authorize remote server. Error: %ld", err);
+    }
   }
 
   // channel : To wide char

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -114,6 +114,10 @@ rb_winevt_query_initialize(VALUE argc, VALUE* argv, VALUE self)
 
   winevtQuery->query = EvtQuery(
     hRemoteHandle, evtChannel, evtXPath, EvtQueryChannelPath | EvtQueryTolerateQueryErrors);
+  err = GetLastError();
+  if (err != ERROR_SUCCESS) {
+    raise_system_error(rb_eRuntimeError, err);
+  }
   winevtQuery->offset = 0L;
   winevtQuery->timeout = 0L;
   winevtQuery->renderAsXML = TRUE;

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -89,7 +89,8 @@ rb_winevt_query_initialize(VALUE argc, VALUE* argv, VALUE self)
     hRemoteHandle = connect_to_remote(winevtSession->server,
                                       winevtSession->domain,
                                       winevtSession->username,
-                                      winevtSession->password);
+                                      winevtSession->password,
+                                      winevtSession->flags);
 
     err = GetLastError();
     if (err != ERROR_SUCCESS) {

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -62,13 +62,15 @@ rb_winevt_query_alloc(VALUE klass)
 /*
  * Initalize Query class.
  *
- * @param channel [String] Querying EventLog channel.
- * @param xpath [String] Querying XPath.
+ * @overload initialize(channel, xpath, session=nil)
+ *   @param channel [String] Querying EventLog channel.
+ *   @param xpath [String] Querying XPath.
+ *   @param session [Session] Session information for remoting access.
  * @return [Query]
  *
  */
 static VALUE
-rb_winevt_query_initialize(VALUE argc, VALUE* argv, VALUE self)
+rb_winevt_query_initialize(VALUE argc, VALUE *argv, VALUE self)
 {
   PWSTR evtChannel, evtXPath;
   VALUE channel, xpath, session;
@@ -431,7 +433,7 @@ rb_winevt_query_set_render_as_xml(VALUE self, VALUE rb_render_as_xml)
  * This method specifies whether preserving qualifiers key or not.
  *
  * @since 0.7.3
- * @param rb_render_as_xml [Boolean]
+ * @param rb_preserve_qualifiers [Boolean]
  */
 static VALUE
 rb_winevt_query_set_preserve_qualifiers(VALUE self, VALUE rb_preserve_qualifiers)

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -237,12 +237,12 @@ rb_winevt_query_render(VALUE self, EVT_HANDLE event)
 }
 
 static VALUE
-rb_winevt_query_message(EVT_HANDLE event, LocaleInfo* localeInfo)
+rb_winevt_query_message(EVT_HANDLE event, LocaleInfo* localeInfo, EVT_HANDLE hRemote)
 {
   WCHAR* wResult;
   VALUE utf8str;
 
-  wResult = get_description(event, localeInfo->langID);
+  wResult = get_description(event, localeInfo->langID, hRemote);
   utf8str = wstr_to_rb_str(CP_UTF8, wResult, -1);
   free(wResult);
 
@@ -354,7 +354,8 @@ rb_winevt_query_each_yield(VALUE self)
   for (int i = 0; i < winevtQuery->count; i++) {
     rb_yield_values(3,
                     rb_winevt_query_render(self, winevtQuery->hEvents[i]),
-                    rb_winevt_query_message(winevtQuery->hEvents[i], winevtQuery->localeInfo),
+                    rb_winevt_query_message(winevtQuery->hEvents[i], winevtQuery->localeInfo,
+                                            winevtQuery->remoteHandle),
                     rb_winevt_query_string_inserts(winevtQuery->hEvents[i]));
   }
   return Qnil;

--- a/ext/winevt/winevt_session.c
+++ b/ext/winevt/winevt_session.c
@@ -1,0 +1,271 @@
+#include <winevt_c.h>
+
+VALUE rb_cSession;
+
+static void session_free(void* ptr);
+
+static const rb_data_type_t rb_winevt_session_type = { "winevt/session",
+                                                       {
+                                                         0,
+                                                         session_free,
+                                                         0,
+                                                       },
+                                                       NULL,
+                                                       NULL,
+                                                       RUBY_TYPED_FREE_IMMEDIATELY };
+
+static void
+session_free(void* ptr)
+{
+  xfree(ptr);
+}
+
+static VALUE
+rb_winevt_session_alloc(VALUE klass)
+{
+  VALUE obj;
+  struct WinevtSession* winevtSession;
+  obj = TypedData_Make_Struct(
+    klass, struct WinevtSession, &rb_winevt_session_type, winevtSession);
+  return obj;
+}
+
+/*
+ * Initalize Session class.
+ *
+ * @return [Session]
+ *
+ */
+static VALUE
+rb_winevt_session_initialize(VALUE self)
+{
+  struct WinevtSession* winevtSession;
+
+  TypedData_Get_Struct(
+      self, struct WinevtSession, &rb_winevt_session_type, winevtSession);
+
+  winevtSession->computerName = NULL;
+  winevtSession->domain = NULL;
+  winevtSession->username = NULL;
+  winevtSession->password= NULL;
+
+  return Qnil;
+}
+
+/*
+ * This method returns computer name for remoting access.
+ *
+ * @return [String]
+ */
+static VALUE
+rb_winevt_session_get_computer_name(VALUE self)
+{
+  struct WinevtSession* winevtSession;
+
+  TypedData_Get_Struct(self, struct WinevtSession, &rb_winevt_session_type, winevtSession);
+
+  if (winevtSession->computerName) {
+    return wstr_to_rb_str(CP_UTF8, winevtSession->computerName, -1);
+  } else {
+    return rb_str_new2("(NULL)");
+  }
+}
+
+/*
+ * This method specifies computer name for remoting access.
+ *
+ * @param rb_computer_name [String] computer name
+ */
+static VALUE
+rb_winevt_session_set_computer_name(VALUE self, VALUE rb_computer_name)
+{
+  struct WinevtSession* winevtSession;
+  DWORD len;
+  VALUE wcomputerName;
+  WCHAR* evtComputerName;
+
+  Check_Type(rb_computer_name, T_STRING);
+
+  TypedData_Get_Struct(self, struct WinevtSession, &rb_winevt_session_type, winevtSession);
+
+  len =
+    MultiByteToWideChar(CP_UTF8, 0,
+                        RSTRING_PTR(rb_computer_name), RSTRING_LEN(rb_computer_name),
+                        NULL, 0);
+  evtComputerName = ALLOCV_N(WCHAR, wcomputerName, len + 1);
+  MultiByteToWideChar(CP_UTF8, 0,
+                      RSTRING_PTR(rb_computer_name), RSTRING_LEN(rb_computer_name),
+                      evtComputerName, len);
+
+  winevtSession->computerName = evtComputerName;
+
+  return Qnil;
+}
+
+/*
+ * This method returns domain for remoting access.
+ *
+ * @return [String]
+ */
+static VALUE
+rb_winevt_session_get_domain(VALUE self)
+{
+  struct WinevtSession* winevtSession;
+
+  TypedData_Get_Struct(self, struct WinevtSession, &rb_winevt_session_type, winevtSession);
+
+  if (winevtSession->domain) {
+    return wstr_to_rb_str(CP_UTF8, winevtSession->domain, -1);
+  } else {
+    return rb_str_new2("(NULL)");
+  }
+}
+
+/*
+ * This method specifies domain for remoting access.
+ *
+ * @param rb_domain [String] domain
+ */
+static VALUE
+rb_winevt_session_set_domain(VALUE self, VALUE rb_domain)
+{
+  struct WinevtSession* winevtSession;
+  DWORD len;
+  VALUE wdomain;
+  WCHAR* evtDomain;
+
+  Check_Type(rb_domain, T_STRING);
+
+  TypedData_Get_Struct(self, struct WinevtSession, &rb_winevt_session_type, winevtSession);
+
+  len =
+    MultiByteToWideChar(CP_UTF8, 0,
+                        RSTRING_PTR(rb_domain), RSTRING_LEN(rb_domain),
+                        NULL, 0);
+  evtDomain = ALLOCV_N(WCHAR, wdomain, len + 1);
+  MultiByteToWideChar(CP_UTF8, 0,
+                      RSTRING_PTR(rb_domain), RSTRING_LEN(rb_domain),
+                      evtDomain, len);
+
+  winevtSession->domain = evtDomain;
+
+  return Qnil;
+}
+
+/*
+ * This method returns username for remoting access.
+ *
+ * @return [String]
+ */
+static VALUE
+rb_winevt_session_get_username(VALUE self)
+{
+  struct WinevtSession* winevtSession;
+
+  TypedData_Get_Struct(self, struct WinevtSession, &rb_winevt_session_type, winevtSession);
+
+  if (winevtSession->username) {
+    return wstr_to_rb_str(CP_UTF8, winevtSession->username, -1);
+  } else {
+    return rb_str_new2("(NULL)");
+  }
+}
+
+/*
+ * This method specifies username for remoting access.
+ *
+ * @param rb_username [String] username
+ */
+static VALUE
+rb_winevt_session_set_username(VALUE self, VALUE rb_username)
+{
+  struct WinevtSession* winevtSession;
+  DWORD len;
+  VALUE wusername;
+  WCHAR* evtUsername;
+
+  Check_Type(rb_username, T_STRING);
+
+  TypedData_Get_Struct(self, struct WinevtSession, &rb_winevt_session_type, winevtSession);
+
+  len =
+    MultiByteToWideChar(CP_UTF8, 0,
+                        RSTRING_PTR(rb_username), RSTRING_LEN(rb_username),
+                        NULL, 0);
+  evtUsername = ALLOCV_N(WCHAR, wusername, len + 1);
+  MultiByteToWideChar(CP_UTF8, 0,
+                      RSTRING_PTR(rb_username), RSTRING_LEN(rb_username),
+                      evtUsername, len);
+
+  winevtSession->username = evtUsername;
+
+  return Qnil;
+}
+
+/*
+ * This method returns password for remoting access.
+ *
+ * @return [String]
+ */
+static VALUE
+rb_winevt_session_get_password(VALUE self)
+{
+  struct WinevtSession* winevtSession;
+
+  TypedData_Get_Struct(self, struct WinevtSession, &rb_winevt_session_type, winevtSession);
+
+  if (winevtSession->password) {
+    return wstr_to_rb_str(CP_UTF8, winevtSession->password, -1);
+  } else {
+    return rb_str_new2("(NULL)");
+  }
+}
+
+/*
+ * This method specifies password for remoting access.
+ *
+ * @param rb_password [String] password
+ */
+static VALUE
+rb_winevt_session_set_password(VALUE self, VALUE rb_password)
+{
+  struct WinevtSession* winevtSession;
+  DWORD len;
+  VALUE wpassword;
+  WCHAR* evtPassword;
+
+  Check_Type(rb_password, T_STRING);
+
+  TypedData_Get_Struct(self, struct WinevtSession, &rb_winevt_session_type, winevtSession);
+
+  len =
+    MultiByteToWideChar(CP_UTF8, 0,
+                        RSTRING_PTR(rb_password), RSTRING_LEN(rb_password),
+                        NULL, 0);
+  evtPassword = ALLOCV_N(WCHAR, wpassword, len + 1);
+  MultiByteToWideChar(CP_UTF8, 0,
+                      RSTRING_PTR(rb_password), RSTRING_LEN(rb_password),
+                      evtPassword, len);
+
+  winevtSession->password = evtPassword;
+
+  return Qnil;
+}
+
+void
+Init_winevt_session(VALUE rb_cEventLog)
+{
+  rb_cSession = rb_define_class_under(rb_cEventLog, "Session", rb_cObject);
+
+  rb_define_alloc_func(rb_cSession, rb_winevt_session_alloc);
+
+  rb_define_method(rb_cSession, "initialize", rb_winevt_session_initialize, 0);
+  rb_define_method(rb_cSession, "computer_name", rb_winevt_session_get_computer_name, 0);
+  rb_define_method(rb_cSession, "computer_name=", rb_winevt_session_set_computer_name, 1);
+  rb_define_method(rb_cSession, "domain", rb_winevt_session_get_domain, 0);
+  rb_define_method(rb_cSession, "domain=", rb_winevt_session_set_domain, 1);
+  rb_define_method(rb_cSession, "username", rb_winevt_session_get_username, 0);
+  rb_define_method(rb_cSession, "username=", rb_winevt_session_set_username, 1);
+  rb_define_method(rb_cSession, "password", rb_winevt_session_get_password, 0);
+  rb_define_method(rb_cSession, "password=", rb_winevt_session_set_password, 1);
+}

--- a/ext/winevt/winevt_session.c
+++ b/ext/winevt/winevt_session.c
@@ -1,5 +1,39 @@
 #include <winevt_c.h>
 
+/* clang-format off */
+/*
+ * Document-class: Winevt::EventLog::Session
+ *
+ * Manage Session information for Windows EventLog.
+ *
+ * @example
+ *  require 'winevt'
+ *
+ *  @session = Winevt::EventLog::Session.new("127.0.0.1")
+ *
+ *  @session.domain = "<EXAMPLEGROUP>"
+ *  @session.username = "<username>"
+ *  @session.password = "<password>"
+ *  # Then pass @session veriable into Winevt::EventLog::Query or
+ *  # Winevt::EventLog::Subscribe#subscribe
+ *  @query = Winevt::EventLog::Query.new(
+ *    "Application",
+ *    "*[System[(Level <= 3) and TimeCreated[timediff(@SystemTime) <= 86400000]]]",
+ *    @session
+ *  )
+ *  # some stuff.
+ *
+ *  @subscribe = Winevt::EventLog::Subscribe.new
+ *  @subscribe.subscribe(
+ *    "Application",
+ *    "*[System[(Level <= 4) and TimeCreated[timediff(@SystemTime) <= 86400000]]]",
+ *    @session
+ *  )
+ *  # And some stuff.
+ * @since v0.9.0
+ */
+/* clang-format on */
+
 VALUE rb_cSession;
 VALUE rb_cRpcLoginFlag;
 
@@ -45,9 +79,16 @@ rb_winevt_session_alloc(VALUE klass)
 /*
  * Initalize Session class.
  *
+ * @overload initialize(server, domain=nil, username=nil, password=nil, flags=Winevt::EventLog::Session::RpcLoginFlag::AuthDefault)
+ *   @param server [String] Server ip address or fqdn.
+ *   @param domain [String] Domain name.
+ *   @param username [String] username on remote server.
+ *   @param password [String] Remote server user password.
+ *   @param flags [Integer] Flags for authentication method choices.
  * @return [Session]
  *
  */
+
 static VALUE
 rb_winevt_session_initialize(VALUE self)
 {
@@ -361,8 +402,24 @@ Init_winevt_session(VALUE rb_cEventLog)
   rb_define_method(rb_cSession, "flags", rb_winevt_session_get_flags, 0);
   rb_define_method(rb_cSession, "flags=", rb_winevt_session_set_flags, 1);
 
+  /*
+   * EVT_RPC_LOGIN_FLAGS enumeration: EvtRpcLoginAuthDefault
+   * @see https://docs.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_rpc_login_flags
+   */
   rb_define_const(rb_cRpcLoginFlag, "AuthDefault", LONG2NUM(EvtRpcLoginAuthDefault));
+  /*
+   * EVT_RPC_LOGIN_FLAGS enumeration: EvtRpcLoginAuthNegociate
+   * @see https://docs.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_rpc_login_flags
+   */
   rb_define_const(rb_cRpcLoginFlag, "AuthNegociate", LONG2NUM(EvtRpcLoginAuthNegotiate));
+  /*
+   * EVT_RPC_LOGIN_FLAGS enumeration: EvtRpcLoginAuthKerberos
+   * @see https://docs.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_rpc_login_flags
+   */
   rb_define_const(rb_cRpcLoginFlag, "AuthKerberos", LONG2NUM(EvtRpcLoginAuthKerberos));
+  /*
+   * EVT_RPC_LOGIN_FLAGS enumeration: EvtRpcLoginAuthNTLM
+   * @see https://docs.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_rpc_login_flags
+   */
   rb_define_const(rb_cRpcLoginFlag, "AuthNTLM", LONG2NUM(EvtRpcLoginAuthNTLM));
 }

--- a/ext/winevt/winevt_session.c
+++ b/ext/winevt/winevt_session.c
@@ -17,6 +17,17 @@ static const rb_data_type_t rb_winevt_session_type = { "winevt/session",
 static void
 session_free(void* ptr)
 {
+  struct WinevtSession* winevtSession = (struct WinevtSession*)ptr;
+
+  if (winevtSession->server)
+    free(winevtSession->server);
+  if (winevtSession->domain)
+    free(winevtSession->domain);
+  if (winevtSession->username)
+    free(winevtSession->username);
+  if (winevtSession->password)
+    free(winevtSession->password);
+
   xfree(ptr);
 }
 

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -185,8 +185,8 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
     }
   }
   if (rb_obj_is_kind_of(rb_session, rb_cSession)) {
-    winevtSession = EventSession(rb_cSession);
-    hRemoteHandle = connect_to_remote(winevtSession->computerName,
+    winevtSession = EventSession(rb_session);
+    hRemoteHandle = connect_to_remote(winevtSession->server,
                                       winevtSession->domain,
                                       winevtSession->username,
                                       winevtSession->password);

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -150,6 +150,7 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
   HANDLE hSignalEvent;
   EVT_HANDLE hRemoteHandle = NULL;
   DWORD len, flags = 0L;
+  DWORD err = ERROR_SUCCESS;
   VALUE wpathBuf, wqueryBuf, wBookmarkBuf;
   PWSTR path, query, bookmarkXml;
   DWORD status = ERROR_SUCCESS;
@@ -190,6 +191,11 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
                                       winevtSession->domain,
                                       winevtSession->username,
                                       winevtSession->password);
+
+    err = GetLastError();
+    if (err != ERROR_SUCCESS) {
+      raise_system_error(rb_eRuntimeError, err);
+    }
   }
 
   // path : To wide char

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -234,7 +234,7 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
     }
     status = GetLastError();
     if (rb_obj_is_kind_of(rb_session, rb_cSession)) {
-      rb_raise(rb_eRuntimeError, "Remoting subscription is not working. errCode: %ld\n", status);
+      rb_raise(rb_eRemoteHandlerError, "Remoting subscription is not working. errCode: %ld\n", status);
     } else {
       raise_system_error(rb_eWinevtQueryError, status);
     }

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -135,10 +135,11 @@ rb_winevt_subscribe_read_existing_events_p(VALUE self)
 /*
  * Subscribe into a Windows EventLog channel.
  *
- * @overload subscribe(path, query, options={})
+ * @overload subscribe(path, query, bookmark=nil, session=nil)
  *   @param path [String] Subscribe Channel
  *   @param query [String] Query string for channel
- *   @option options [Bookmark] bookmark Bookmark class instance.
+ *   @param bookmark [Bookmark] bookmark Bookmark class instance.
+ *   @param session [Session] Session information for remoting access.
  * @return [Boolean]
  *
  */
@@ -548,7 +549,7 @@ rb_winevt_subscribe_set_render_as_xml(VALUE self, VALUE rb_render_as_xml)
  * This method specifies whether preserving qualifiers key or not.
  *
  * @since 0.7.3
- * @param rb_render_as_xml [Boolean]
+ * @param rb_preserve_qualifiers [Boolean]
  */
 static VALUE
 rb_winevt_subscribe_set_preserve_qualifiers(VALUE self, VALUE rb_preserve_qualifiers)

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -231,7 +231,11 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
       CloseHandle(hSignalEvent);
     }
     status = GetLastError();
-    raise_system_error(rb_eWinevtQueryError, status);
+    if (rb_obj_is_kind_of(rb_session, rb_cSession)) {
+      rb_raise(rb_eRuntimeError, "Remoting subscription is not working. errCode: %ld\n", status);
+    } else {
+      raise_system_error(rb_eWinevtQueryError, status);
+    }
   }
 
   if (winevtSubscribe->subscription != NULL) {

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -190,7 +190,8 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
     hRemoteHandle = connect_to_remote(winevtSession->server,
                                       winevtSession->domain,
                                       winevtSession->username,
-                                      winevtSession->password);
+                                      winevtSession->password,
+                                      winevtSession->flags);
 
     err = GetLastError();
     if (err != ERROR_SUCCESS) {

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -359,12 +359,12 @@ rb_winevt_subscribe_render(VALUE self, EVT_HANDLE event)
 }
 
 static VALUE
-rb_winevt_subscribe_message(EVT_HANDLE event, LocaleInfo* localeInfo)
+rb_winevt_subscribe_message(EVT_HANDLE event, LocaleInfo* localeInfo, EVT_HANDLE hRemote)
 {
   WCHAR* wResult;
   VALUE utf8str;
 
-  wResult = get_description(event, localeInfo->langID);
+  wResult = get_description(event, localeInfo->langID, hRemote);
   utf8str = wstr_to_rb_str(CP_UTF8, wResult, -1);
   free(wResult);
 
@@ -407,7 +407,8 @@ rb_winevt_subscribe_each_yield(VALUE self)
   for (int i = 0; i < winevtSubscribe->count; i++) {
     rb_yield_values(3,
                     rb_winevt_subscribe_render(self, winevtSubscribe->hEvents[i]),
-                    rb_winevt_subscribe_message(winevtSubscribe->hEvents[i], winevtSubscribe->localeInfo),
+                    rb_winevt_subscribe_message(winevtSubscribe->hEvents[i], winevtSubscribe->localeInfo,
+                                                winevtSubscribe->remoteHandle),
                     rb_winevt_subscribe_string_inserts(winevtSubscribe->hEvents[i]));
   }
 

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -77,12 +77,13 @@ render_to_rb_str(EVT_HANDLE handle, DWORD flags)
 }
 
 EVT_HANDLE
-connect_to_remote(WCHAR* computerName, WCHAR* domain, WCHAR* username, WCHAR* password)
+connect_to_remote(LPWSTR computerName, LPWSTR domain, LPWSTR username, LPWSTR password)
 {
   EVT_HANDLE hRemote = NULL;
   EVT_RPC_LOGIN Credentials;
 
   RtlZeroMemory(&Credentials, sizeof(EVT_RPC_LOGIN));
+
   Credentials.Server = computerName;
   Credentials.Domain = domain;
   Credentials.User = username;

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -88,7 +88,7 @@ connect_to_remote(LPWSTR computerName, LPWSTR domain, LPWSTR username, LPWSTR pa
   Credentials.Domain = domain;
   Credentials.User = username;
   Credentials.Password = password;
-  Credentials.Flags = EvtRpcLoginAuthNegotiate;
+  Credentials.Flags = EvtRpcLoginAuthDefault;
 
   hRemote = EvtOpenSession(EvtRpcLogin, &Credentials, 0, 0);
 

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -453,7 +453,7 @@ cleanup:
 }
 
 WCHAR*
-get_description(EVT_HANDLE handle, LANGID langID)
+get_description(EVT_HANDLE handle, LANGID langID, EVT_HANDLE hRemote)
 {
 #define BUFSIZE 4096
   std::vector<WCHAR> buffer(BUFSIZE);
@@ -490,7 +490,7 @@ get_description(EVT_HANDLE handle, LANGID langID)
 
   // Open publisher metadata
   hMetadata = EvtOpenPublisherMetadata(
-    nullptr,
+    hRemote,
     values[0].StringVal,
     nullptr,
     MAKELCID(langID, SORT_DEFAULT),

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -76,6 +76,26 @@ render_to_rb_str(EVT_HANDLE handle, DWORD flags)
   return result;
 }
 
+EVT_HANDLE
+connect_to_remote(WCHAR* computerName, WCHAR* domain, WCHAR* username, WCHAR* password)
+{
+  EVT_HANDLE hRemote = NULL;
+  EVT_RPC_LOGIN Credentials;
+
+  RtlZeroMemory(&Credentials, sizeof(EVT_RPC_LOGIN));
+  Credentials.Server = computerName;
+  Credentials.Domain = domain;
+  Credentials.User = username;
+  Credentials.Password = password;
+  Credentials.Flags = EvtRpcLoginAuthNegotiate;
+
+  hRemote = EvtOpenSession(EvtRpcLogin, &Credentials, 0, 0);
+
+  SecureZeroMemory(&Credentials, sizeof(EVT_RPC_LOGIN));
+
+  return hRemote;
+}
+
 static std::wstring
 guid_to_wstr(const GUID& guid)
 {

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -77,7 +77,8 @@ render_to_rb_str(EVT_HANDLE handle, DWORD flags)
 }
 
 EVT_HANDLE
-connect_to_remote(LPWSTR computerName, LPWSTR domain, LPWSTR username, LPWSTR password)
+connect_to_remote(LPWSTR computerName, LPWSTR domain, LPWSTR username, LPWSTR password,
+                  EVT_RPC_LOGIN_FLAGS flags)
 {
   EVT_HANDLE hRemote = NULL;
   EVT_RPC_LOGIN Credentials;
@@ -88,7 +89,7 @@ connect_to_remote(LPWSTR computerName, LPWSTR domain, LPWSTR username, LPWSTR pa
   Credentials.Domain = domain;
   Credentials.User = username;
   Credentials.Password = password;
-  Credentials.Flags = EvtRpcLoginAuthDefault;
+  Credentials.Flags = flags;
 
   hRemote = EvtOpenSession(EvtRpcLogin, &Credentials, 0, 0);
 

--- a/lib/winevt.rb
+++ b/lib/winevt.rb
@@ -7,6 +7,7 @@ require "winevt/bookmark"
 require "winevt/query"
 require "winevt/subscribe"
 require "winevt/version"
+require "winevt/session"
 
 module Winevt
   # Your code goes here...

--- a/lib/winevt/session.rb
+++ b/lib/winevt/session.rb
@@ -1,0 +1,15 @@
+module Winevt
+  class EventLog
+    class Session
+      alias_method :initialize_raw, :initialize
+
+      def initialize(server, domain = nil, username = nil, password = nil)
+        initialize_raw
+        self.server = server
+        self.domain = domain if domain.is_a?(String)
+        self.username = username if username.is_a?(String)
+        self.password = password if password.is_a?(String)
+      end
+    end
+  end
+end

--- a/lib/winevt/subscribe.rb
+++ b/lib/winevt/subscribe.rb
@@ -3,8 +3,11 @@ module Winevt
     class Subscribe
       alias_method :subscribe_raw, :subscribe
 
-      def subscribe(path, query, bookmark = nil)
-        if bookmark.is_a?(Winevt::EventLog::Bookmark)
+      def subscribe(path, query, bookmark = nil, session = nil)
+        if bookmark.is_a?(Winevt::EventLog::Bookmark) &&
+           session.is_a?(Winevt::EventLog::Session)
+          subscribe_raw(path, query, bookmark.render, session)
+        elsif bookmark.is_a?(Winevt::EventLog::Bookmark)
           subscribe_raw(path, query, bookmark.render)
         else
           subscribe_raw(path, query)

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -311,5 +311,17 @@ class WinevtTest < Test::Unit::TestCase
       @session.password = "changeme!"
       assert_equal("changeme!", @session.password)
     end
+
+    def test_flags
+      @session.flags = Winevt::EventLog::Session::RpcLoginFlag::AuthNTLM
+      assert_equal(Winevt::EventLog::Session::RpcLoginFlag::AuthNTLM,
+                   @session.flags)
+      @session.flags = :kerberos
+      assert_equal(Winevt::EventLog::Session::RpcLoginFlag::AuthKerberos,
+                   @session.flags)
+      @session.flags = "ntlm"
+      assert_equal(Winevt::EventLog::Session::RpcLoginFlag::AuthNTLM,
+                   @session.flags)
+    end
   end
 end

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -282,4 +282,34 @@ class WinevtTest < Test::Unit::TestCase
       end
     end
   end
+
+  class SessionTest < self
+    def setup
+      @session = Winevt::EventLog::Session.new
+    end
+
+    def test_server
+      assert_equal("(NULL)", @session.server)
+      @session.server = "127.0.0.1"
+      assert_equal("127.0.0.1", @session.server)
+    end
+
+    def test_domain
+      assert_equal("(NULL)", @session.domain)
+      @session.domain = "EXAMPLEGROUP"
+      assert_equal("EXAMPLEGROUP", @session.domain)
+    end
+
+    def test_username
+      assert_equal("(NULL)", @session.username)
+      @session.username = "testuser"
+      assert_equal("testuser", @session.username)
+    end
+
+    def test_password
+      assert_equal("(NULL)", @session.password)
+      @session.password = "changeme!"
+      assert_equal("changeme!", @session.password)
+    end
+  end
 end

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -15,6 +15,14 @@ class WinevtTest < Test::Unit::TestCase
       end
     end
 
+    def test_query_with_session
+      query = "*[System[(Level <= 3) and TimeCreated[timediff(@SystemTime) <= 86400000]]]"
+      session = Winevt::EventLog::Session.new("127.0.0.1")
+      assert do
+        Winevt::EventLog::Query.new("Application", query, session)
+      end
+    end
+
     def test_next
       assert_true(@query.next)
     end
@@ -146,6 +154,14 @@ class WinevtTest < Test::Unit::TestCase
       end
     end
 
+    def test_query_with_session
+      query = "*[System[(Level <= 3) and TimeCreated[timediff(@SystemTime) <= 86400000]]]"
+      session = Winevt::EventLog::Session.new("127.0.0.1")
+      assert do
+        @subscribe.subscribe("Application", query, session)
+      end
+    end
+
     def test_subscribe_twice
       subscribe = Winevt::EventLog::Subscribe.new
       subscribe.subscribe("Application", "*")
@@ -157,6 +173,13 @@ class WinevtTest < Test::Unit::TestCase
     def test_subscribe_with_bookmark
       subscribe = Winevt::EventLog::Subscribe.new
       subscribe.subscribe("Application", "*", @bookmark)
+      assert_true(subscribe.next)
+    end
+
+    def test_subscribe_with_bookmark_and_session
+      subscribe = Winevt::EventLog::Subscribe.new
+      session = Winevt::EventLog::Session.new("127.0.0.1")
+      subscribe.subscribe("Application", "*", @bookmark, session)
       assert_true(subscribe.next)
     end
 

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -285,12 +285,10 @@ class WinevtTest < Test::Unit::TestCase
 
   class SessionTest < self
     def setup
-      @session = Winevt::EventLog::Session.new
+      @session = Winevt::EventLog::Session.new("127.0.0.1")
     end
 
     def test_server
-      assert_equal("(NULL)", @session.server)
-      @session.server = "127.0.0.1"
       assert_equal("127.0.0.1", @session.server)
     end
 


### PR DESCRIPTION
To confirm this, we should prepare Windows Firewall for RPC login and adding EventLog Readers group into accessing account:
https://help.sumologic.com/03Send-Data/Sources/01Sources-for-Installed-Collectors/Remote-Windows-Event-Log-Source/Preconfigure-a-Machine-to-Collect-Remote-Windows-Events 