### PR TITLE
Cancel long living operations

### DIFF
--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -32,7 +32,7 @@ static const rb_data_type_t rb_winevt_query_type = { "winevt/query",
                                                      RUBY_TYPED_FREE_IMMEDIATELY };
 
 static void
-dispose_handles(struct WinevtQuery* winevtQuery)
+close_handles(struct WinevtQuery* winevtQuery)
 {
   if (winevtQuery->query)
     EvtClose(winevtQuery->query);
@@ -50,7 +50,7 @@ static void
 query_free(void* ptr)
 {
   struct WinevtQuery* winevtQuery = (struct WinevtQuery*)ptr;
-  dispose_handles(winevtQuery);
+  close_handles(winevtQuery);
 
   xfree(ptr);
 }
@@ -542,6 +542,23 @@ rb_winevt_query_cancel(VALUE self)
   }
 }
 
+/*
+ * This method closes channel handles forcibly.
+ *
+ * @since 0.9.1
+ */
+static VALUE
+rb_winevt_query_close(VALUE self)
+{
+  struct WinevtQuery* winevtQuery;
+
+  TypedData_Get_Struct(
+    self, struct WinevtQuery, &rb_winevt_query_type, winevtQuery);
+  close_handles(winevtQuery);
+
+  return Qnil;
+}
+
 void
 Init_winevt_query(VALUE rb_cEventLog)
 {
@@ -619,4 +636,8 @@ Init_winevt_query(VALUE rb_cEventLog)
    * @since 0.9.1
    */
   rb_define_method(rb_cQuery, "cancel", rb_winevt_query_cancel, 0);
+  /*
+   * @since 0.9.1
+   */
+  rb_define_method(rb_cQuery, "close", rb_winevt_query_close, 0);
 }

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -34,16 +34,22 @@ static const rb_data_type_t rb_winevt_query_type = { "winevt/query",
 static void
 close_handles(struct WinevtQuery* winevtQuery)
 {
-  if (winevtQuery->query)
+  if (winevtQuery->query) {
     EvtClose(winevtQuery->query);
-
-  for (int i = 0; i < winevtQuery->count; i++) {
-    if (winevtQuery->hEvents[i])
-      EvtClose(winevtQuery->hEvents[i]);
+    winevtQuery->query = NULL;
   }
 
-  if (winevtQuery->remoteHandle)
+  for (int i = 0; i < winevtQuery->count; i++) {
+    if (winevtQuery->hEvents[i]) {
+      EvtClose(winevtQuery->hEvents[i]);
+      winevtQuery->hEvents[i] = NULL;
+    }
+  }
+
+  if (winevtQuery->remoteHandle) {
     EvtClose(winevtQuery->remoteHandle);
+    winevtQuery->remoteHandle = NULL;
+  }
 }
 
 static void
@@ -554,6 +560,7 @@ rb_winevt_query_close(VALUE self)
 
   TypedData_Get_Struct(
     self, struct WinevtQuery, &rb_winevt_query_type, winevtQuery);
+
   close_handles(winevtQuery);
 
   return Qnil;

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -41,23 +41,33 @@ static const rb_data_type_t rb_winevt_subscribe_type = { "winevt/subscribe",
 static void
 close_handles(struct WinevtSubscribe* winevtSubscribe)
 {
-  if (winevtSubscribe->signalEvent)
+  if (winevtSubscribe->signalEvent) {
     CloseHandle(winevtSubscribe->signalEvent);
+    winevtSubscribe->signalEvent = NULL;
+  }
 
-  if (winevtSubscribe->subscription)
+  if (winevtSubscribe->subscription) {
     EvtClose(winevtSubscribe->subscription);
+    winevtSubscribe->subscription = NULL;
+  }
 
-  if (winevtSubscribe->bookmark)
+  if (winevtSubscribe->bookmark) {
     EvtClose(winevtSubscribe->bookmark);
+    winevtSubscribe->bookmark = NULL;
+  }
 
   for (int i = 0; i < winevtSubscribe->count; i++) {
     if (winevtSubscribe->hEvents[i]) {
       EvtClose(winevtSubscribe->hEvents[i]);
+      winevtSubscribe->hEvents[i] = NULL;
     }
   }
+  winevtSubscribe->count = 0;
 
-  if (winevtSubscribe->remoteHandle)
+  if (winevtSubscribe->remoteHandle) {
     EvtClose(winevtSubscribe->remoteHandle);
+    winevtSubscribe->remoteHandle = NULL;
+  }
 }
 
 static void

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -27,6 +27,11 @@ class WinevtTest < Test::Unit::TestCase
       assert_true(@query.next)
     end
 
+    def test_cancel
+      assert_true(@query.cancel)
+      assert_false(@query.next)
+    end
+
     def test_timeout
       @query.timeout = 1
       assert_equal(1, @query.timeout)
@@ -199,6 +204,11 @@ class WinevtTest < Test::Unit::TestCase
 
     def test_next
       assert_true(@subscribe.next)
+    end
+
+    def test_cancel
+      assert_true(@subscribe.cancel)
+      assert_false(@subscribe.next)
     end
 
     def test_read_existing_events

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -32,6 +32,14 @@ class WinevtTest < Test::Unit::TestCase
       assert_false(@query.next)
     end
 
+    def test_cancel_and_close
+      assert_true(@query.cancel)
+      assert_false(@query.next)
+      assert_nothing_raised do
+        @query.close
+      end
+    end
+
     def test_timeout
       @query.timeout = 1
       assert_equal(1, @query.timeout)
@@ -209,6 +217,14 @@ class WinevtTest < Test::Unit::TestCase
     def test_cancel
       assert_true(@subscribe.cancel)
       assert_false(@subscribe.next)
+    end
+
+    def test_cancel_and_close
+      assert_true(@subscribe.cancel)
+      assert_false(@subscribe.next)
+      assert_nothing_raised do
+        @subscribe.close
+      end
     end
 
     def test_read_existing_events


### PR DESCRIPTION
We should call `EvtCancel` on refreshing or cancelling subscription/query handles:

* https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtcancel