### PR TITLE
Do not override error code

### DIFF
--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -41,7 +41,8 @@ void  raise_system_error(VALUE error, DWORD errorCode);
 VALUE render_to_rb_str(EVT_HANDLE handle, DWORD flags);
 EVT_HANDLE connect_to_remote(LPWSTR computerName, LPWSTR domain,
                              LPWSTR username, LPWSTR password,
-                             EVT_RPC_LOGIN_FLAGS flags);
+                             EVT_RPC_LOGIN_FLAGS flags,
+                             DWORD *error_code);
 WCHAR* get_description(EVT_HANDLE handle, LANGID langID, EVT_HANDLE hRemote);
 VALUE get_values(EVT_HANDLE handle);
 VALUE render_system_event(EVT_HANDLE handle, BOOL preserve_qualifiers);

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -91,7 +91,7 @@ rb_winevt_query_initialize(VALUE argc, VALUE *argv, VALUE self)
   EVT_HANDLE hRemoteHandle = NULL;
   DWORD len;
   VALUE wchannelBuf, wpathBuf;
-  DWORD err;
+  DWORD err = ERROR_SUCCESS;
 
   rb_scan_args(argc, argv, "21", &channel, &xpath, &session);
   Check_Type(channel, T_STRING);
@@ -104,9 +104,8 @@ rb_winevt_query_initialize(VALUE argc, VALUE *argv, VALUE self)
                                       winevtSession->domain,
                                       winevtSession->username,
                                       winevtSession->password,
-                                      winevtSession->flags);
-
-    err = GetLastError();
+                                      winevtSession->flags,
+                                      &err);
     if (err != ERROR_SUCCESS) {
       raise_system_error(rb_eRuntimeError, err);
     }

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -208,9 +208,8 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
                                       winevtSession->domain,
                                       winevtSession->username,
                                       winevtSession->password,
-                                      winevtSession->flags);
-
-    err = GetLastError();
+                                      winevtSession->flags,
+                                      &err);
     if (err != ERROR_SUCCESS) {
       raise_system_error(rb_eRuntimeError, err);
     }

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -242,13 +242,13 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
   hSubscription =
     EvtSubscribe(hRemoteHandle, hSignalEvent, path, query, hBookmark, NULL, NULL, flags);
   if (!hSubscription) {
+    status = GetLastError();
     if (hBookmark != NULL) {
       EvtClose(hBookmark);
     }
     if (hSignalEvent != NULL) {
       CloseHandle(hSignalEvent);
     }
-    status = GetLastError();
     if (rb_obj_is_kind_of(rb_session, rb_cSession)) {
       rb_raise(rb_eRemoteHandlerError, "Remoting subscription is not working. errCode: %ld\n", status);
     } else {
@@ -272,13 +272,13 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
   } else {
     winevtSubscribe->bookmark = EvtCreateBookmark(NULL);
     if (winevtSubscribe->bookmark == NULL) {
+      status = GetLastError();
       if (hSubscription != NULL) {
         EvtClose(hSubscription);
       }
       if (hSignalEvent != NULL) {
         CloseHandle(hSignalEvent);
       }
-      status = GetLastError();
       raise_system_error(rb_eWinevtQueryError, status);
     }
   }

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -564,13 +564,13 @@ render_system_event(EVT_HANDLE hEvent, BOOL preserve_qualifiers)
                   pRenderedValues,
                   &dwBufferUsed,
                   &dwPropertyCount);
+        status = GetLastError();
       } else {
         EvtClose(hContext);
         rb_raise(rb_eRuntimeError, "Failed to malloc memory with %lu\n", status);
       }
     }
 
-    status = GetLastError();
     if (ERROR_SUCCESS != status) {
       EvtClose(hContext);
       ALLOCV_END(vRenderedValues);

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -78,7 +78,7 @@ render_to_rb_str(EVT_HANDLE handle, DWORD flags)
 
 EVT_HANDLE
 connect_to_remote(LPWSTR computerName, LPWSTR domain, LPWSTR username, LPWSTR password,
-                  EVT_RPC_LOGIN_FLAGS flags)
+                  EVT_RPC_LOGIN_FLAGS flags, DWORD *error_code)
 {
   EVT_HANDLE hRemote = NULL;
   EVT_RPC_LOGIN Credentials;
@@ -92,6 +92,10 @@ connect_to_remote(LPWSTR computerName, LPWSTR domain, LPWSTR username, LPWSTR pa
   Credentials.Flags = flags;
 
   hRemote = EvtOpenSession(EvtRpcLogin, &Credentials, 0, 0);
+  if (!hRemote) {
+    *error_code = GetLastError();
+    return hRemote;
+  }
 
   SecureZeroMemory(&Credentials, sizeof(EVT_RPC_LOGIN));
 


### PR DESCRIPTION
There are some cases that Win32 API fails, but the error code is not get correctly (ErrorCode = 0)
This situation occurs because GetLastError is not called appropriately.
