### PR TITLE
utils: Use ZeroMemory for safety

### DIFF
--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -10,11 +10,24 @@ wstr_to_rb_str(UINT cp, const WCHAR* wstr, int clen)
 {
   VALUE vstr;
   CHAR* ptr;
+  int ret = -1;
+  DWORD err = ERROR_SUCCESS;
+  if (wstr == NULL) {
+    return rb_utf8_str_new_cstr("");
+  }
+
   int len = WideCharToMultiByte(cp, 0, wstr, clen, nullptr, 0, nullptr, nullptr);
   ptr = ALLOCV_N(CHAR, vstr, len);
   // For memory safety.
   ZeroMemory(ptr, sizeof(CHAR) * len);
-  WideCharToMultiByte(cp, 0, wstr, clen, ptr, len, nullptr, nullptr);
+  ret = WideCharToMultiByte(cp, 0, wstr, clen, ptr, len, nullptr, nullptr);
+  // return 0 should be failure.
+  // ref: https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte#return-value
+  if (ret == 0) {
+    err = GetLastError();
+    ALLOCV_END(vstr);
+    raise_system_error(rb_eRuntimeError, err);
+  }
   VALUE str = rb_utf8_str_new_cstr(ptr);
   ALLOCV_END(vstr);
 

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -12,6 +12,8 @@ wstr_to_rb_str(UINT cp, const WCHAR* wstr, int clen)
   CHAR* ptr;
   int len = WideCharToMultiByte(cp, 0, wstr, clen, nullptr, 0, nullptr, nullptr);
   ptr = ALLOCV_N(CHAR, vstr, len);
+  // For memory safety.
+  ZeroMemory(ptr, sizeof(CHAR) * len);
   WideCharToMultiByte(cp, 0, wstr, clen, ptr, len, nullptr, nullptr);
   VALUE str = rb_utf8_str_new_cstr(ptr);
   ALLOCV_END(vstr);


### PR DESCRIPTION
`CHAR* ptr;` variable is not initailized by NULL.
For memory safety, we should use `ZeroMemory` to clear with '\0'.
Otherwise, ptr will have a garbage value.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

Maybe related to https://github.com/fluent/fluent-plugin-windows-eventlog/issues/79