### PR TITLE
utils: Support Binary type of string inserts decoding

### DIFF
--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -134,7 +134,7 @@ make_displayable_binary_string(PBYTE bin, size_t length)
 {
   const char *HEX_TABLE = "0123456789ABCDEF";
   CHAR *buffer;
-  int size = length * 2;
+  int size = length * 2 + 1;
   size_t i, j;
   unsigned int idx = 0;
   VALUE vbuffer;
@@ -144,8 +144,6 @@ make_displayable_binary_string(PBYTE bin, size_t length)
   }
 
   buffer = ALLOCV_N(CHAR, vbuffer, size);
-  // For memory safety.
-  ZeroMemory(buffer, sizeof(CHAR) * size);
 
   for (i = 0; i < length; i++) {
     for (j = 0; j < 2; j++) {
@@ -153,6 +151,7 @@ make_displayable_binary_string(PBYTE bin, size_t length)
       buffer[2*i+(1-j)] = HEX_TABLE[idx];
     }
   }
+  buffer[size - 1] = '\0';
 
   VALUE str = rb_str_new2(buffer);
   ALLOCV_END(vbuffer);


### PR DESCRIPTION
I found that binary type on string inserts can be decoded by hex characters.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>