### PR TITLE
Add a new error Winevt::EventLog::ChannelNotFoundError

### DIFF
--- a/ext/winevt/winevt.c
+++ b/ext/winevt/winevt.c
@@ -5,6 +5,7 @@ VALUE rb_cQuery;
 VALUE rb_cEventLog;
 VALUE rb_cSubscribe;
 VALUE rb_eWinevtQueryError;
+VALUE rb_eChannelNotFoundError;
 VALUE rb_eRemoteHandlerError;
 
 static ID id_call;
@@ -17,6 +18,7 @@ Init_winevt(void)
   rb_cQuery = rb_define_class_under(rb_cEventLog, "Query", rb_cObject);
   rb_cSubscribe = rb_define_class_under(rb_cEventLog, "Subscribe", rb_cObject);
   rb_eWinevtQueryError = rb_define_class_under(rb_cQuery, "Error", rb_eStandardError);
+  rb_eChannelNotFoundError = rb_define_class_under(rb_cEventLog, "ChannelNotFoundError", rb_eStandardError);
   rb_eRemoteHandlerError = rb_define_class_under(rb_cSubscribe, "RemoteHandlerError", rb_eRuntimeError);
 
   Init_winevt_channel(rb_cEventLog);

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -37,7 +37,8 @@ VALUE wstr_to_rb_str(UINT cp, const WCHAR* wstr, int clen);
 #if defined(__cplusplus)
 [[ noreturn ]]
 #endif /* __cplusplus */
-void  raise_system_error(VALUE error, DWORD errorCode);
+void raise_system_error(VALUE error, DWORD errorCode);
+void raise_channel_not_found_error(VALUE channelPath);
 VALUE render_to_rb_str(EVT_HANDLE handle, DWORD flags);
 EVT_HANDLE connect_to_remote(LPWSTR computerName, LPWSTR domain,
                              LPWSTR username, LPWSTR password,
@@ -58,6 +59,7 @@ extern VALUE rb_cChannel;
 extern VALUE rb_cBookmark;
 extern VALUE rb_cSubscribe;
 extern VALUE rb_eWinevtQueryError;
+extern VALUE rb_eChannelNotFoundError;
 extern VALUE rb_eRemoteHandlerError;
 extern VALUE rb_cLocale;
 extern VALUE rb_cSession;

--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -131,6 +131,9 @@ rb_winevt_query_initialize(VALUE argc, VALUE *argv, VALUE self)
     hRemoteHandle, evtChannel, evtXPath, EvtQueryChannelPath | EvtQueryTolerateQueryErrors);
   err = GetLastError();
   if (err != ERROR_SUCCESS) {
+    if (err == ERROR_EVT_CHANNEL_NOT_FOUND) {
+      raise_channel_not_found_error(channel);
+    }
     raise_system_error(rb_eRuntimeError, err);
   }
   winevtQuery->offset = 0L;

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -248,10 +248,17 @@ rb_winevt_subscribe_subscribe(int argc, VALUE* argv, VALUE self)
     if (hSignalEvent != NULL) {
       CloseHandle(hSignalEvent);
     }
+
     if (rb_obj_is_kind_of(rb_session, rb_cSession)) {
       rb_raise(rb_eRemoteHandlerError, "Remoting subscription is not working. errCode: %ld\n", status);
-    } else {
+    }
+
+    switch (status) {
+    case ERROR_EVT_CHANNEL_NOT_FOUND:
+      raise_channel_not_found_error(rb_path);
+    default:
       raise_system_error(rb_eWinevtQueryError, status);
+      break;
     }
   }
 

--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -56,6 +56,16 @@ raise_system_error(VALUE error, DWORD errorCode)
 #pragma GCC diagnostic pop
 }
 
+void
+raise_channel_not_found_error(VALUE channelPath)
+{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat="
+#pragma GCC diagnostic ignored "-Wformat-extra-args"
+  rb_raise(rb_eChannelNotFoundError, "Channel Not Found: %" PRIsVALUE, channelPath);
+#pragma GCC diagnostic pop
+}
+
 VALUE
 render_to_rb_str(EVT_HANDLE handle, DWORD flags)
 {

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -300,6 +300,14 @@ class WinevtTest < Test::Unit::TestCase
         @subscribe.locale = "ex_EX" # Invalid Locale
       end
     end
+
+    def test_channel_not_found
+      bookmark = Winevt::EventLog::Bookmark.new
+      subscribe = Winevt::EventLog::Subscribe.new
+      assert_raise(Winevt::EventLog::ChannelNotFoundError) do
+        subscribe.subscribe("NonExistentChannel", "*")
+      end
+    end
   end
 
   class ChannelTest < self


### PR DESCRIPTION
Our customer who uses fluent-plugin-windows-evnetlog wants to skip unknown channels without stoping Fluentd. It's reasonable because channels are dynamically added or removed. But winevt_c doesn't provide a way to distinguish `ERROR_EVT_CHANNEL_NOT_FOUND` and other errors.

This commit adds `Winevt::EventLog::ChannelNotFoundError` and raise it when `ERROR_EVT_CHANNEL_NOT_FOUND` is occurred.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>