### PR TITLE
Raise an exception if an event signal notifies a failure state on EvtSubscribe

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '3.0', '3.1', '3.2' ]
         os:
           - ubuntu-latest
     name: Ruby ${{ matrix.ruby }} building fat gem testing on ${{ matrix.os }}

--- a/ext/winevt/winevt.c
+++ b/ext/winevt/winevt.c
@@ -7,6 +7,7 @@ VALUE rb_cSubscribe;
 VALUE rb_eWinevtQueryError;
 VALUE rb_eChannelNotFoundError;
 VALUE rb_eRemoteHandlerError;
+VALUE rb_eSubscribeHandlerError;
 
 static ID id_call;
 
@@ -20,6 +21,7 @@ Init_winevt(void)
   rb_eWinevtQueryError = rb_define_class_under(rb_cQuery, "Error", rb_eStandardError);
   rb_eChannelNotFoundError = rb_define_class_under(rb_cEventLog, "ChannelNotFoundError", rb_eStandardError);
   rb_eRemoteHandlerError = rb_define_class_under(rb_cSubscribe, "RemoteHandlerError", rb_eRuntimeError);
+  rb_eSubscribeHandlerError = rb_define_class_under(rb_cSubscribe, "SubscribeHandlerError", rb_eRuntimeError);
 
   Init_winevt_channel(rb_cEventLog);
   Init_winevt_bookmark(rb_cEventLog);

--- a/ext/winevt/winevt_c.h
+++ b/ext/winevt/winevt_c.h
@@ -61,6 +61,7 @@ extern VALUE rb_cSubscribe;
 extern VALUE rb_eWinevtQueryError;
 extern VALUE rb_eChannelNotFoundError;
 extern VALUE rb_eRemoteHandlerError;
+extern VALUE rb_eSubscribeHandlerError;
 extern VALUE rb_cLocale;
 extern VALUE rb_cSession;
 

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -357,12 +357,16 @@ rb_winevt_subscribe_next(VALUE self)
     return Qfalse;
   }
 
-  /* If a signalEvent notifies a failure, raise
-   * SubscribeHandlerError to detect stale subscription.
+  /* If a signalEvent notifies whether a state of processed event(s)
+   * is existing or not.
+   * For checking for a result of WaitForSingleObject,
+   * we need to raise SubscribeHandlerError exception when
+   * WAIT_FAILED is detected for further investigations.
    * Note that we don't need to wait explicitly here.
    * Because this function is inside of each enumerator.
    * So, WaitForSingleObject should return immediately and should be
-   * processed with the latter each loop if there is no more items. */
+   * processed with the latter each loops if there is no more items.
+   * Just intended to check that there is no errors here. */
   dwWait = WaitForSingleObject(winevtSubscribe->signalEvent, 0);
   if (dwWait == WAIT_FAILED) {
     raise_system_error(rb_eSubscribeHandlerError, GetLastError());

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -357,6 +357,12 @@ rb_winevt_subscribe_next(VALUE self)
     return Qfalse;
   }
 
+  /* If a signalEvent notifies a failure, raise
+   * SubscribeHandlerError to detect stale subscription.
+   * Note that we don't need to wait explicitly here.
+   * Because this function is inside of each enumerator.
+   * So, WaitForSingleObject should return immediately and should be
+   * processed with the latter each loop if there is no more items. */
   dwWait = WaitForSingleObject(winevtSubscribe->signalEvent, 0);
   if (dwWait == WAIT_FAILED) {
     raise_system_error(rb_eSubscribeHandlerError, GetLastError());

--- a/ext/winevt/winevt_subscribe.c
+++ b/ext/winevt/winevt_subscribe.c
@@ -64,8 +64,6 @@ close_handles(struct WinevtSubscribe* winevtSubscribe)
   }
   winevtSubscribe->count = 0;
 
-  ResetEvent(winevtSubscribe->signalEvent);
-
   if (winevtSubscribe->remoteHandle) {
     EvtClose(winevtSubscribe->remoteHandle);
     winevtSubscribe->remoteHandle = NULL;
@@ -359,7 +357,7 @@ rb_winevt_subscribe_next(VALUE self)
     return Qfalse;
   }
 
-  dwWait = WaitForSingleObject(winevtSubscribe->signalEvent, INFINITE);
+  dwWait = WaitForSingleObject(winevtSubscribe->signalEvent, 0);
   if (dwWait == WAIT_FAILED) {
     raise_system_error(rb_eSubscribeHandlerError, GetLastError());
   } else if (dwWait != WAIT_OBJECT_0) {
@@ -379,6 +377,8 @@ rb_winevt_subscribe_next(VALUE self)
     if (ERROR_NO_MORE_ITEMS != status) {
       return Qfalse;
     }
+
+    ResetEvent(winevtSubscribe->signalEvent);
   }
 
   if (status == ERROR_SUCCESS) {


### PR DESCRIPTION
With event signal system, we're able to check the status of the event subscriptions.
This could be helpful for detecting failure of the subscribed handles.

---

This pull type of subscription,
we need to add the following actions:

1. Create an EventObject for handling signal events
2. Reset signal when ERROR_NO_MORE_ITEMS from EvtNext

This should ensure the windows eventlog collection correctly.
Also, we shouldn't specify the INFINITE waiting on WaitForSingleObject
because this function is inside of enumerator.
So, it causes infinite blocking for this case.