### PR TITLE
Skip SID translation for capability SIDs

### DIFF
--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -888,7 +888,8 @@ render_system_event(EVT_HANDLE hEvent, BOOL preserve_qualifiers, BOOL preserveSI
       }
       /* S-1-15-3- is used for capability SIDs. So, we need to skip
        * SID translation.
-       * See also: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+       * ref: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+       * See also: https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/sids-not-resolve-into-friendly-names
        */
       if (strnicmp(pwsSid, "S-1-15-3-", 9) != 0) {
         if (ExpandSIDWString(pRenderedValues[EvtSystemUserID].SidVal,


### PR DESCRIPTION
S-1-15-3- prefixed SIDs are used for indicating capabilities and not mapped for the actual users.
We need to skip SID translation to eliminate the needless trying to translate SIDs.

ref: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers#capability-sids