### PR TITLE
winevt_channel: fix double free to avoid SEGV

### DIFF
--- a/ext/winevt/winevt_channel.c
+++ b/ext/winevt/winevt_channel.c
@@ -132,8 +132,6 @@ DWORD is_subscribable_channel_p(EVT_HANDLE hChannel, BOOL force_enumerate)
           EvtGetChannelConfigProperty(hChannel, (EVT_CHANNEL_CONFIG_PROPERTY_ID)Id, 0, dwBufferSize, pProperty, &dwBufferUsed);
           status = GetLastError();
         } else {
-          free(pProperty);
-
           status = ERROR_OUTOFMEMORY;
 
           goto cleanup;
@@ -141,8 +139,6 @@ DWORD is_subscribable_channel_p(EVT_HANDLE hChannel, BOOL force_enumerate)
       }
 
       if (ERROR_SUCCESS != status) {
-        free(pProperty);
-
         goto cleanup;
       }
     }


### PR DESCRIPTION
`free(pProperty)` is executed as error handling,
and then `free(pProperty)` is executed again as cleanup with same pointer address.

https://github.com/fluent-plugins-nursery/winevt_c/blob/dde5d46e3fc7439550deabae1208f321ae9065c4/ext/winevt/winevt_channel.c#L124-L157

With double free, it causes SEGV.

So, this PR will fix this problem