### PR TITLE
Rakefile: restore release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require "bundler/gem_tasks"
 require "rake/testtask"
 require 'rake/clean'
 


### PR DESCRIPTION
I removed following lines by mistake at https://github.com/fluent-plugins-nursery/winevt_c/pull/50

```
require 'bundler'
Bundler::GemHelper.install_tasks
```

These lines are required for `release` task in rake command.
