### PR TITLE
winevt_utils: fix handler leak with Winevt::EventLog::Query::Error

### DIFF
--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -562,6 +562,7 @@ get_description(EVT_HANDLE handle, LANGID langID, EVT_HANDLE hRemote)
   }
 
   if (status != ERROR_SUCCESS) {
+    EvtClose(renderContext);
     raise_system_error(rb_eWinevtQueryError, status);
   }
 


### PR DESCRIPTION
When raise exception, we should close handler because it causes resource leak.

The following handlers must be closed, I think.

https://github.com/fluent-plugins-nursery/winevt_c/blob/1c6f3dbc65ad37e951375c4d355569b9c46ea786/ext/winevt/winevt_utils.cpp#L546-L547