### PR TITLE
winevt_utils: fix memory leak when handle SID

### DIFF
--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -603,6 +603,7 @@ static char* convert_wstr(wchar_t *wstr)
   int len = 0;
   CHAR *ptr = NULL;
   DWORD err = ERROR_SUCCESS;
+  char *dup_str = NULL;
 
   len = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL);
   if (len == 0) {
@@ -622,7 +623,10 @@ static char* convert_wstr(wchar_t *wstr)
     raise_system_error(rb_eRuntimeError, err);
   }
 
-  return strdup(ptr);
+  dup_str = strdup(ptr);
+  RB_ALLOCV_END(vstr);
+
+  return dup_str;
 }
 
 static int ExpandSIDWString(PSID sid, CHAR **out_expanded)


### PR DESCRIPTION
`strdup()` allocate the heap and copy into the heap area.
If we allocated heap area when preparing the source data, we must release the area after `strdup()` invoked, like

https://github.com/fluent-plugins-nursery/winevt_c/blob/576256d89b3180d19a1ddaf543f6e7cb59402a8d/ext/winevt/winevt_utils.cpp#L672-L676