### PR TITLE
winevt_query: fix remote handle leak on error

### DIFF
--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -119,6 +119,9 @@ rb_winevt_query_initialize(VALUE argc, VALUE *argv, VALUE self)
     flags = EvtQueryChannelPath | EvtQueryTolerateQueryErrors;
     break;
   default:
+    if (hRemoteHandle != NULL) {
+      EvtClose(hRemoteHandle);
+    }
     rb_raise(rb_eArgError, "Expected a String, a Symbol, a Fixnum, or a NilClass instance");
   }
 
@@ -142,6 +145,9 @@ rb_winevt_query_initialize(VALUE argc, VALUE *argv, VALUE self)
     hRemoteHandle, evtChannel, evtXPath, flags);
   err = GetLastError();
   if (err != ERROR_SUCCESS) {
+    if (hRemoteHandle != NULL) {
+      EvtClose(hRemoteHandle);
+    }
     if (err == ERROR_EVT_CHANNEL_NOT_FOUND) {
       raise_channel_not_found_error(channel);
     }


### PR DESCRIPTION
Normally, `hRemoteHandle` is assigned to `winevtQuery->remoteHandle` and safely released by garbage collection via the close_handles function:
https://github.com/fluent-plugins-nursery/winevt_c/blob/f7fd42099fbbf9c650607d744e18fc9e57907d3f/ext/winevt/winevt_query.c#L50

However, if `EvtQuery` fails, a Ruby exception is raised before this assignment happens.
Because the struct does not have the handle yet, the GC cannot clean it up, resulting in a resource leak.

This PR fixes the issue by explicitly closing `hRemoteHandle` before raising the exception.