### PR TITLE
Fix SEGV and heap over-read in winevt_utils

### DIFF
--- a/ext/winevt/winevt_utils.cpp
+++ b/ext/winevt/winevt_utils.cpp
@@ -455,6 +455,7 @@ get_message(EVT_HANDLE hMetadata, EVT_HANDLE handle)
 
           std::wstring ret(reinterpret_cast<WCHAR*>(lpMsgBuf));
           std::copy(ret.begin(), ret.end(), std::back_inserter(result));
+          result.push_back(L'\0');
           LocalFree(lpMsgBuf);
 
           goto cleanup;
@@ -512,6 +513,7 @@ get_message(EVT_HANDLE hMetadata, EVT_HANDLE handle)
 
               std::wstring ret(reinterpret_cast<WCHAR*>(lpMsgBuf));
               std::copy(ret.begin(), ret.end(), std::back_inserter(result));
+              result.push_back(L'\0');
               LocalFree(lpMsgBuf);
 
               goto cleanup;
@@ -593,6 +595,10 @@ cleanup:
 
   if (hMetadata)
     EvtClose(hMetadata);
+
+  if (result.empty()) {
+    return _wcsdup(L"");
+  }
 
   return _wcsdup(result.data());
 }


### PR DESCRIPTION
When `hMetadata` cannot be opened or `FormatMessageW` fallback paths are triggered, `result` could either be empty or miss a null terminator (`L'\0'`). Passing an empty vector's `.data()` (which can be `nullptr`) or a non-null-terminated buffer to `_wcsdup` leads to undefined behavior, causing high-frequency SEGV or heap over-reads.

This fix prevents crashes by explicitly adding `L'\0'` in the fallback paths and returning `_wcsdup(L"")` early if the result vector is empty.