### PR TITLE
Fix false positive error handling in rb_winevt_query_initialize

### DIFF
--- a/ext/winevt/winevt_query.c
+++ b/ext/winevt/winevt_query.c
@@ -143,8 +143,8 @@ rb_winevt_query_initialize(VALUE argc, VALUE *argv, VALUE self)
 
   winevtQuery->query = EvtQuery(
     hRemoteHandle, evtChannel, evtXPath, flags);
-  err = GetLastError();
-  if (err != ERROR_SUCCESS) {
+  if (winevtQuery->query == NULL) {
+    err = GetLastError();
     if (hRemoteHandle != NULL) {
       EvtClose(hRemoteHandle);
     }


### PR DESCRIPTION
Win32 APIs do not guarantee that `GetLastError()` is cleared to `ERROR_SUCCESS` on successful calls.
The previous implementation could falsely raise an exception if a leftover error code was present from a prior, unrelated API call, even when `EvtQuery` successfully returned a valid handle.