### PR TITLE
Omit test_subscribe_twice when Security channel is inaccessible

### DIFF
--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -179,7 +179,11 @@ class WinevtTest < Test::Unit::TestCase
       subscribe = Winevt::EventLog::Subscribe.new
       subscribe.subscribe("Application", "*")
       assert_true(subscribe.next)
-      subscribe.subscribe("Security", "*")
+      begin
+        subscribe.subscribe("Security", "*")
+      rescue Winevt::EventLog::Query::Error => e
+        omit("Security channel requires SeSecurityPrivilege: #{e.message.lines.first.strip}")
+      end
       assert_true(subscribe.next)
     end
 


### PR DESCRIPTION
`test_subscribe_twice` reads the Security channel, which requires `SeSecurityPrivilege`.
Non-elevated developers always hit `ERROR_ACCESS_DENIED`, so `rake` could not go green without running the whole suite as administrator.

The test's original intent for choosing Security is unclear, so rather than substituting another channel, omit the test when the privilege is missing.

CI runners are elevated and still exercise it.