### PR TITLE
Fix type confusion in Bookmark#update

### DIFF
--- a/ext/winevt/winevt_bookmark.c
+++ b/ext/winevt/winevt_bookmark.c
@@ -109,6 +109,10 @@ rb_winevt_bookmark_update(VALUE self, VALUE event)
   struct WinevtQuery* winevtQuery;
   struct WinevtBookmark* winevtBookmark;
 
+  if (!rb_obj_is_kind_of(event, rb_cQuery)) {
+    rb_raise(rb_eArgError, "Expected a Query instance");
+  }
+
   winevtQuery = EventQuery(event);
 
   TypedData_Get_Struct(

--- a/test/test_winevt.rb
+++ b/test/test_winevt.rb
@@ -134,6 +134,18 @@ class WinevtTest < Test::Unit::TestCase
       assert_true(@bookmark.update(@query))
     end
 
+    data("fixnum" => 42,
+         "string" => "not a query",
+         "object" => Object.new,
+         "array"  => [],
+         "nil"    => nil,
+         "symbol" => :boom)
+    def test_update_type_confusion(arg)
+      assert_raise(ArgumentError) do
+        @bookmark.update(arg)
+      end
+    end
+
     def test_update_with_seek_bookmark
       @query.next
       assert_true(@bookmark.update(@query))


### PR DESCRIPTION
`Bookmark#update` read its argument through the raw `DATA_PTR` macro (`EventQuery`) with no type-tag check, unlike `Query#seek`, `Query.new` and `Subscribe#subscribe` which all guard with `rb_obj_is_kind_of`. 
Passing any non-Query object reinterpreted arbitrary memory as struct `WinevtQuery` and dereferenced `->count / ->hEvents[]`, crashing the VM with an access violation.

Guard the argument with `rb_obj_is_kind_of(event, rb_cQuery)` and raise `ArgumentError` for non-Query values, matching the existing pattern. 